### PR TITLE
Add attribution for joshuadavidthomas/agent-skills

### DIFF
--- a/skills/crafting-effective-readmes/README.md
+++ b/skills/crafting-effective-readmes/README.md
@@ -174,3 +174,7 @@ crafting-effective-readmes/
 ## Related Skills
 
 - `writing-clearly-and-concisely` - For general prose quality, clear writing, and avoiding AI patterns
+
+## Attribution
+
+- Original skill by @joshuadavidthomas from [joshuadavidthomas/agent-skills](https://github.com/joshuadavidthomas/agent-skills) (MIT)

--- a/skills/reducing-entropy/README.md
+++ b/skills/reducing-entropy/README.md
@@ -133,3 +133,7 @@ You've succeeded when:
 ---
 
 **Bias toward deletion. Measure the end state.**
+
+## Attribution
+
+- Original skill by @joshuadavidthomas from [joshuadavidthomas/agent-skills](https://github.com/joshuadavidthomas/agent-skills) (MIT)

--- a/skills/writing-clearly-and-concisely/README.md
+++ b/skills/writing-clearly-and-concisely/README.md
@@ -151,5 +151,7 @@ Add the skill to project knowledge or paste SKILL.md contents into your conversa
 
 ## Attribution
 
+- Original skill by @joshuadavidthomas from [joshuadavidthomas/agent-skills](https://github.com/joshuadavidthomas/agent-skills) (MIT)
+- Adapted from [obra/the-elements-of-style](https://github.com/obra/the-elements-of-style)
 - Writing principles from *The Elements of Style* by William Strunk Jr. (1918)
 - AI pattern research from Wikipedia's field guide to AI-generated content detection


### PR DESCRIPTION
These three skills originated from [https://github.com/joshuadavidthomas/agent-skills](https://github.com/joshuadavidthomas/agent-skills) (created 2025‑12‑04). Adding attribution to the READMEs.

- crafting-effective-readmes
- reducing-entropy
- writing-clearly-and-concisely