### PR TITLE
feat: improve skill scores for agent-toolkit

### DIFF
--- a/skills/agent-md-refactor/SKILL.md
+++ b/skills/agent-md-refactor/SKILL.md
@@ -1,24 +1,12 @@
 ---
 name: agent-md-refactor
-description: Refactor bloated AGENTS.md, CLAUDE.md, or similar agent instruction files to follow progressive disclosure principles. Splits monolithic files into organized, linked documentation.
+description: Refactor bloated AGENTS.md, CLAUDE.md, COPILOT.md, or similar agent instruction files into organized, linked documentation following progressive disclosure principles. Use when files are too long, hard to maintain, or the user wants to split, reorganize, break up, or simplify their agent configuration files.
 license: MIT
 ---
 
 # Agent MD Refactor
 
 Refactor bloated agent instruction files (AGENTS.md, CLAUDE.md, COPILOT.md, etc.) to follow **progressive disclosure principles** - keeping essentials at root and organizing the rest into linked, categorized files.
-
----
-
-## Triggers
-
-Use this skill when:
-- "refactor my AGENTS.md" / "refactor my CLAUDE.md"
-- "split my agent instructions"
-- "organize my CLAUDE.md file"
-- "my AGENTS.md is too long"
-- "progressive disclosure for my instructions"
-- "clean up my agent config"
 
 ---
 
@@ -101,9 +89,10 @@ Organize remaining instructions into logical categories.
 
 **Grouping rules:**
 1. Each file should be self-contained for its topic
-2. Aim for 3-8 files (not too granular, not too broad)
+2. Aim for 3-8 files (not too granular, not too broad) — too many categories cause fragmentation
 3. Name files clearly: `{topic}.md`
-4. Include only actionable instructions
+4. Include only actionable instructions — vague guidance wastes tokens
+5. Use a flat structure with links — avoid deep nesting
 
 ---
 
@@ -214,18 +203,6 @@ Identify instructions that should be removed entirely.
 [ ] Verify: Root file is under 50 lines
 [ ] Verify: All links work correctly
 ```
-
----
-
-## Anti-Patterns
-
-| Avoid | Why | Instead |
-|-------|-----|---------|
-| Keeping everything in root | Bloated, hard to maintain | Split into linked files |
-| Too many categories | Fragmentation | Consolidate related topics |
-| Vague instructions | Wastes tokens, no value | Be specific or delete |
-| Duplicating defaults | Agent already knows | Only override when needed |
-| Deep nesting | Hard to navigate | Flat structure with links |
 
 ---
 

--- a/skills/backend-to-frontend-handoff-docs/SKILL.md
+++ b/skills/backend-to-frontend-handoff-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-to-frontend-handoff-docs
-description: Create API handoff documentation for frontend developers. Use when backend work is complete and needs to be documented for frontend integration, or user says 'create handoff', 'document API', 'frontend handoff', or 'API documentation'.
+description: Generate API handoff documentation including endpoint specifications, request/response schemas, authentication details, validation rules, and example payloads for frontend developers. Use when backend work is complete and needs to be documented for frontend integration, or user says 'create handoff', 'document API', 'frontend handoff', or 'API documentation'.
 ---
 
 # API Handoff Mode
@@ -8,8 +8,6 @@ description: Create API handoff documentation for frontend developers. Use when 
 > **No Chat Output**: Produce the handoff document only. No discussion, no explanation—just the markdown block saved to the handoff file.
 
 You are a backend developer completing API work. Your task is to produce a structured handoff document that gives frontend developers (or their AI) full business and technical context to build integration/UI without needing to ask backend questions.
-
-> **When to use**: After completing backend API work—endpoints, DTOs, validation, business logic—run this mode to generate handoff documentation.
 
 > **Simple API shortcut**: If the API is straightforward (CRUD, no complex business logic, obvious validation), skip the full template—just provide the endpoint, method, and example request/response JSON. Frontend can infer the rest.
 
@@ -109,7 +107,6 @@ interface ExampleDto {
 ---
 
 ## Rules
-- **NO CHAT OUTPUT**—produce only the handoff markdown block, nothing else.
 - Be precise: types, constraints, examples—not vague prose.
 - Include real example payloads where helpful.
 - Surface non-obvious behaviors—don't assume frontend will "just know."
@@ -119,4 +116,4 @@ interface ExampleDto {
 - If something is incomplete or TBD, say so explicitly.
 
 ## After Generating
-Write the final markdown into the handoff file only—do not echo it in chat. (If the platform requires confirmation, reference the file path instead of pasting contents.)
+Write the final markdown into the handoff file only—reference the file path instead of pasting contents in chat.

--- a/skills/c4-architecture/SKILL.md
+++ b/skills/c4-architecture/SKILL.md
@@ -12,7 +12,8 @@ Generate software architecture documentation using C4 model diagrams in Mermaid 
 1. **Understand scope** - Determine which C4 level(s) are needed based on audience
 2. **Analyze codebase** - Explore the system to identify components, containers, and relationships
 3. **Generate diagrams** - Create Mermaid C4 diagrams at appropriate abstraction levels
-4. **Document** - Write diagrams to markdown files with explanatory context
+4. **Validate** - Verify all relationships have technology labels, every element has a description, and diagrams render correctly in Mermaid preview
+5. **Document** - Write diagrams to markdown files with explanatory context
 
 ## C4 Diagram Levels
 
@@ -203,22 +204,14 @@ Use `$offsetX` and `$offsetY` to fix overlapping relationship labels.
 4. **Include technology labels** - "JSON/HTTPS", "JDBC", "gRPC"
 5. **Stay under 20 elements per diagram** - Split complex systems into multiple diagrams
 
-### Clarity Guidelines
-
-1. **Start at Level 1** - Context diagrams help frame the system scope
-2. **One diagram per file** - Keep diagrams focused on a single abstraction level
-3. **Meaningful aliases** - Use descriptive aliases (e.g., `orderService` not `s1`)
-4. **Concise descriptions** - Keep descriptions under 50 characters when possible
-5. **Always include a title** - "System Context diagram for [System Name]"
-
-### What to Avoid
+### C4-Specific Gotchas
 
 See [references/common-mistakes.md](references/common-mistakes.md) for detailed anti-patterns:
-- Confusing containers (deployable) vs components (non-deployable)
-- Modeling shared libraries as containers
-- Showing message brokers as single containers instead of individual topics
-- Adding undefined abstraction levels like "subcomponents"
-- Removing type labels to "simplify" diagrams
+- Confusing containers (deployable units) vs components (non-deployable modules within a container)
+- Modeling shared libraries as containers — they are not independently deployable
+- Showing message brokers as single containers instead of individual topics/queues
+- Adding undefined abstraction levels like "subcomponents" — C4 has exactly four levels
+- Removing type labels to "simplify" diagrams — types are what make C4 diagrams self-describing
 
 ## Microservices Guidelines
 

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: codex
-description: Use when the user asks to run Codex CLI (codex exec, codex resume) or references OpenAI Codex for code analysis, refactoring, or automated editing. Uses GPT-5.2 by default for state-of-the-art software engineering.
+description: Executes OpenAI Codex CLI for AI-assisted code generation, multi-file editing, and automated refactoring. Use when the user asks to run Codex CLI commands (codex exec, codex resume), generate code patches, apply multi-file edits, execute AI-assisted shell commands, or references OpenAI Codex for code analysis or automated editing.
 ---
 
 # Codex Skill Guide
 
 ## Running a Task
-1. Default to `gpt-5.2` model. Ask the user (via `AskUserQuestion`) which reasoning effort to use (`xhigh`,`high`, `medium`, or `low`). User can override model if needed (see Model Options below).
+
+1. Default to `gpt-5.2` model. Ask the user (via `AskUserQuestion`) which reasoning effort to use (`xhigh`, `high`, `medium`, or `low`). User can override model if needed (see Model Options below).
 2. Select the sandbox mode required for the task; default to `--sandbox read-only` unless edits or network access are necessary.
 3. Assemble the command with the appropriate options:
    - `-m, --model <MODEL>`
@@ -14,53 +15,64 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
    - `--sandbox <read-only|workspace-write|danger-full-access>`
    - `--full-auto`
    - `-C, --cd <DIR>`
-   - `--skip-git-repo-check`
-3. Always use --skip-git-repo-check.
-4. When continuing a previous session, use `codex exec --skip-git-repo-check resume --last` via stdin. When resuming don't use any configuration flags unless explicitly requested by the user e.g. if he species the model or the reasoning effort when requesting to resume a session. Resume syntax: `echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. All flags have to be inserted between exec and resume.
-5. **IMPORTANT**: By default, append `2>/dev/null` to all `codex exec` commands to suppress thinking tokens (stderr). Only show stderr if the user explicitly requests to see thinking tokens or if debugging is needed.
-6. Run the command, capture stdout/stderr (filtered as appropriate), and summarize the outcome for the user.
-7. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
+   - `--skip-git-repo-check` (always include this flag)
+4. **IMPORTANT**: Append `2>/dev/null` to all `codex exec` commands to suppress thinking tokens (stderr). Only show stderr if the user explicitly requests it or debugging is needed.
+5. Run the command, capture output, and summarize the outcome for the user.
+6. **Validate**: If the exit code is non-zero, report the error and ask the user how to proceed before retrying.
+7. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume'."
+
+### Resuming a Session
+
+When continuing a previous session, pipe the new prompt via stdin. Do not add configuration flags unless the user explicitly requests a different model or reasoning effort:
+
+```bash
+echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null
+```
+
+All flags must be inserted between `exec` and `resume`. The resumed session inherits model, reasoning effort, and sandbox mode from the original.
 
 ### Quick Reference
-| Use case | Sandbox mode | Key flags |
+
+| Use case | Sandbox mode | Command pattern |
 | --- | --- | --- |
-| Read-only review or analysis | `read-only` | `--sandbox read-only 2>/dev/null` |
-| Apply local edits | `workspace-write` | `--sandbox workspace-write --full-auto 2>/dev/null` |
-| Permit network or broad access | `danger-full-access` | `--sandbox danger-full-access --full-auto 2>/dev/null` |
-| Resume recent session | Inherited from original | `echo "prompt" \| codex exec --skip-git-repo-check resume --last 2>/dev/null` (no flags allowed) |
-| Run from another directory | Match task needs | `-C <DIR>` plus other flags `2>/dev/null` |
+| Read-only review or analysis | `read-only` | `codex exec --skip-git-repo-check -m gpt-5.2 --sandbox read-only "prompt" 2>/dev/null` |
+| Apply local edits | `workspace-write` | `codex exec --skip-git-repo-check --sandbox workspace-write --full-auto "prompt" 2>/dev/null` |
+| Network or broad access | `danger-full-access` | `codex exec --skip-git-repo-check --sandbox danger-full-access --full-auto "prompt" 2>/dev/null` |
+| Resume recent session | Inherited | `echo "prompt" \| codex exec --skip-git-repo-check resume --last 2>/dev/null` |
+| Run from another directory | Match task needs | `codex exec --skip-git-repo-check -C <DIR> "prompt" 2>/dev/null` |
 
 ## Model Options
 
-| Model | Best for | Context window | Key features |
-| --- | --- | --- | --- |
-| `gpt-5.2-max` | **Max model**: Ultra-complex reasoning, deep problem analysis | 400K input / 128K output | 76.3% SWE-bench, adaptive reasoning, $1.25/$10.00 |
-| `gpt-5.2` ⭐ | **Flagship model**: Software engineering, agentic coding workflows | 400K input / 128K output | 76.3% SWE-bench, adaptive reasoning, $1.25/$10.00 |
-| `gpt-5.2-mini` | Cost-efficient coding (4x more usage allowance) | 400K input / 128K output | Near SOTA performance, $0.25/$2.00 |
-| `gpt-5.1-thinking` | Ultra-complex reasoning, deep problem analysis | 400K input / 128K output | Adaptive thinking depth, runs 2x slower on hardest tasks |
+| Model | Best for |
+| --- | --- |
+| `gpt-5.2` (default) | Software engineering, agentic coding workflows |
+| `gpt-5.2-max` | Ultra-complex reasoning, deep problem analysis |
+| `gpt-5.2-mini` | Cost-efficient coding (4x more usage allowance) |
+| `gpt-5.1-thinking` | Adaptive thinking depth for hardest tasks |
 
-**GPT-5.2 Advantages**: 76.3% SWE-bench (vs 72.8% GPT-5), 30% faster on average tasks, better tool handling, reduced hallucinations, improved code quality. Knowledge cutoff: September 30, 2024.
+All models support 400K input / 128K output context windows.
 
-**Reasoning Effort Levels**:
-- `xhigh` - Ultra-complex tasks (deep problem analysis, complex reasoning, deep understanding of the problem)
-- `high` - Complex tasks (refactoring, architecture, security analysis, performance optimization)
-- `medium` - Standard tasks (refactoring, code organization, feature additions, bug fixes)
-- `low` - Simple tasks (quick fixes, simple changes, code formatting, documentation)
+### Reasoning Effort Levels
 
-**Cached Input Discount**: 90% off ($0.125/M tokens) for repeated context, cache lasts up to 24 hours.
+| Level | When to use | Examples |
+| --- | --- | --- |
+| `xhigh` | Ultra-complex tasks | Deep problem analysis, complex multi-system reasoning |
+| `high` | Complex tasks | Architecture refactoring, security analysis, performance optimization |
+| `medium` | Standard tasks | Code organization, feature additions, bug fixes |
+| `low` | Simple tasks | Quick fixes, formatting, documentation updates |
 
 ## Following Up
-- After every `codex` command, immediately use `AskUserQuestion` to confirm next steps, collect clarifications, or decide whether to resume with `codex exec resume --last`.
-- When resuming, pipe the new prompt via stdin: `echo "new prompt" | codex exec resume --last 2>/dev/null`. The resumed session automatically uses the same model, reasoning effort, and sandbox mode from the original session.
-- Restate the chosen model, reasoning effort, and sandbox mode when proposing follow-up actions.
+
+1. After every `codex` command, use `AskUserQuestion` to confirm next steps or decide whether to resume.
+2. Restate the chosen model, reasoning effort, and sandbox mode when proposing follow-up actions.
 
 ## Error Handling
-- Stop and report failures whenever `codex --version` or a `codex exec` command exits non-zero; request direction before retrying.
-- Before you use high-impact flags (`--full-auto`, `--sandbox danger-full-access`, `--skip-git-repo-check`) ask the user for permission using AskUserQuestion unless it was already given.
-- When output includes warnings or partial results, summarize them and ask how to adjust using `AskUserQuestion`.
+
+1. **Non-zero exit**: Stop, report the failure, and request direction via `AskUserQuestion` before retrying.
+2. **High-impact flags**: Before using `--full-auto`, `--sandbox danger-full-access`, or `--skip-git-repo-check`, ask permission via `AskUserQuestion` unless already granted.
+3. **Warnings or partial results**: Summarize issues and ask how to adjust via `AskUserQuestion`.
+4. **Validation checkpoint**: After each `codex exec` run, check the exit code. If non-zero, inspect stderr (`codex exec ... 2>&1`), adjust the prompt or flags, and retry with user approval.
 
 ## CLI Version
 
-Requires Codex CLI v0.57.0 or later for GPT-5.2 model support. The CLI defaults to `gpt-5.2` on macOS/Linux and `gpt-5.2` on Windows. Check version: `codex --version`
-
-Use `/model` slash command within a Codex session to switch models, or configure default in `~/.codex/config.toml`.
+Requires Codex CLI v0.57.0+. Check version: `codex --version`. Use `/model` within a session to switch models, or set defaults in `~/.codex/config.toml`.

--- a/skills/crafting-effective-readmes/SKILL.md
+++ b/skills/crafting-effective-readmes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crafting-effective-readmes
-description: Use when writing or improving README files. Not all READMEs are the same — provides templates and guidance matched to your audience and project type.
+description: Generate and improve README.md files — structure sections, write installation instructions, create usage examples, format code blocks, and add badges. Use when writing or improving README files, project documentation, repo descriptions, or markdown docs. Provides templates and guidance matched to your audience and project type.
 ---
 
 # Crafting Effective READMEs

--- a/skills/daily-meeting-update/SKILL.md
+++ b/skills/daily-meeting-update/SKILL.md
@@ -12,31 +12,9 @@ Generate a daily standup/meeting update through an **interactive interview**. Ne
 
 ## Workflow
 
-```
-START
-  │
-  ▼
-┌─────────────────────────────────────────────────────┐
-│ Phase 1: DETECT & OFFER INTEGRATIONS                │
-│ • Check: Claude Code history? gh CLI? jira CLI?     │
-│ • Claude Code → Pull yesterday's session digest     │
-│   → User selects relevant items via multiSelect     │
-│ • GitHub/Jira → Ask user, pull if approved          │
-│ • Pull data NOW (before interview)                  │
-├─────────────────────────────────────────────────────┤
-│ Phase 2: INTERVIEW (with insights)                  │
-│ • Show pulled data as context                       │
-│ • Yesterday: "I see you merged PR #123, what else?" │
-│ • Today: What will you work on?                     │
-│ • Blockers: Anything blocking you?                  │
-│ • Topics: Anything to discuss at end of meeting?    │
-├─────────────────────────────────────────────────────┤
-│ Phase 3: GENERATE UPDATE                            │
-│ • Combine interview answers + tool data             │
-│ • Format as clean Markdown                          │
-│ • Present to user                                   │
-└─────────────────────────────────────────────────────┘
-```
+1. **Detect & Offer Integrations** - Silently check for gh/jira/Claude Code, ask user for consent, pull approved data
+2. **Interview (with insights)** - Ask 4 questions using pulled data as context to trigger memory
+3. **Generate Update** - Combine interview answers + tool data into clean Markdown
 
 ---
 
@@ -104,8 +82,6 @@ Options:
 **Key insight**: Store results to use as context in Phase 2 interview.
 
 ### Step 4: Offer Claude Code History
-
-This integration captures everything you worked on with Claude Code — useful for recalling work that isn't in git or Jira.
 
 **Detection:**
 ```bash
@@ -301,108 +277,19 @@ python3 ~/.claude/skills/daily-meeting-update/scripts/claude_digest.py --project
 
 ---
 
-## Example Session
+## Examples
 
-```
-Claude: "Let's prepare your daily! I detected GitHub configured. Want me to pull your recent activity?"
-User: "Yes"
-
-Claude: "Which repos should I check?"
-User: "backend-api and frontend-app"
-
-[Claude pulls GitHub data silently]
-
-Claude: "I can also pull your Claude Code session history from yesterday. Want me to check?"
-User: "Yes"
-
-[Claude runs digest script, gets 5 sessions]
-
-Claude: "Here are your Claude Code sessions from yesterday. Select the ones relevant to your standup:"
-  ☑ Fix authentication timeout bug (backend-api)
-  ☑ Implement OAuth flow (backend-api)
-  ☐ Update personal blog (blog) - [user unchecks personal project]
-  ☑ Research payment providers (docs)
-  ☐ Debugging test failures (experiments)
-
-User: [selects 3 relevant items]
-
-Claude: "Here's what I found from your activity:
-- Merged PR #120: fix login timeout
-- Opened PR #125: feat: add OAuth flow
-- Reviewed PR #123 (approved), PR #456 (changes requested)
-- 5 commits in backend-api
-- [From Claude Code] Fix authentication timeout bug
-- [From Claude Code] Implement OAuth flow
-- [From Claude Code] Research payment providers
-
-Anything else you worked on yesterday that I missed?"
-User: "No, that covers it"
-
-Claude: "What will you work on today?"
-User: "Continue the OAuth feature and deploy to staging"
-
-Claude: "Any blockers?"
-User: "No"
-
-Claude: "Any topic to bring up at the end of the daily?"
-User: "Yes, I want to discuss the architecture of the new payments module"
-
-[Claude generates update]
-```
+For a complete example session and output template, see [references/examples.md](references/examples.md).
 
 ---
 
-## Output Example
+## Constraints
 
-```markdown
-# Daily Update - 2026-01-22
-
-## Yesterday
-- Worked on authentication feature
-- Research on payment providers
-- Merged PR #120 (fix: login timeout)
-- Opened PR #125 (feat: add OAuth flow)
-
-## Today
-- Continue OAuth feature
-- Deploy to staging
-
-## Blockers
-- No blockers
-
-## PRs & Reviews
-- **Opened:** PR #125 - feat: add OAuth flow
-- **Merged:** PR #120 - fix: login timeout
-- **Reviews:** PR #123 (approved), PR #456 (changes requested)
-
-## Topics for Discussion
-- Architecture of the new payments module
-
----
-*Links:*
-- https://github.com/org/repo/pull/125
-- https://github.com/org/repo/pull/120
-```
-
----
-
-## Anti-Patterns
-
-| Avoid | Why (Expert Knowledge) | Instead |
-|-------|------------------------|---------|
-| Run gh/jira without asking | Users may have personal repos visible, or be in a sensitive project context they don't want exposed | Always ask first, let user choose repos |
-| Assume current directory is the only project | Developers often work on 2-5 repos simultaneously (frontend, backend, infra) | Ask "Which projects are you working on?" |
-| Skip interview even with tool data | Tools capture WHAT happened but miss WHY and context (research, meetings, planning) | Interview is primary, tools supplement |
-| Generate update before all 4 questions | User might have critical blocker or discussion topic that changes the narrative | Complete interview, then generate |
-| Include raw commit messages | Commit messages are often cryptic ("fix", "wip") and don't tell the story | Summarize into human-readable outcomes |
-| Ask for data after interview | Showing insights during interview makes questions smarter ("I see you merged PR #123, anything else?") | Pull data first, then interview with context |
-
----
-
-## NEVER
-
-- **NEVER assume tools are configured** — Many devs have gh installed but not authenticated, or jira CLI pointing to wrong instance
-- **NEVER skip the "Topics for Discussion" question** — This is often the most valuable part of standup that tools can't capture
-- **NEVER generate more than 15 bullets** — Standup should be <2 minutes to read; long updates lose the audience
-- **NEVER include ticket/PR numbers without context** — "PROJ-123" means nothing; always include title or summary
-- **NEVER pull data from repos user didn't explicitly approve** — Even if you can see other repos, respect boundaries
+- **Never assume tools are configured** — detect silently, ask before pulling
+- **Never skip "Topics for Discussion"** — often the most valuable part that tools cannot capture
+- **Never generate more than 15 bullets** — standup should be <2 minutes to read
+- **Never include ticket/PR numbers without context** — always include title or summary
+- **Never pull data from repos user didn't approve** — respect boundaries
+- **Always pull data before interview** — showing insights makes questions smarter
+- **Always complete all 4 questions before generating** — blockers or discussion topics may change the narrative
+- **Summarize, don't copy** — raw commit messages ("fix", "wip") don't tell the story

--- a/skills/daily-meeting-update/references/examples.md
+++ b/skills/daily-meeting-update/references/examples.md
@@ -1,0 +1,82 @@
+# Daily Meeting Update - Examples
+
+## Example Session
+
+```
+Claude: "Let's prepare your daily! I detected GitHub configured. Want me to pull your recent activity?"
+User: "Yes"
+
+Claude: "Which repos should I check?"
+User: "backend-api and frontend-app"
+
+[Claude pulls GitHub data silently]
+
+Claude: "I can also pull your Claude Code session history from yesterday. Want me to check?"
+User: "Yes"
+
+[Claude runs digest script, gets 5 sessions]
+
+Claude: "Here are your Claude Code sessions from yesterday. Select the ones relevant to your standup:"
+  ☑ Fix authentication timeout bug (backend-api)
+  ☑ Implement OAuth flow (backend-api)
+  ☐ Update personal blog (blog) - [user unchecks personal project]
+  ☑ Research payment providers (docs)
+  ☐ Debugging test failures (experiments)
+
+User: [selects 3 relevant items]
+
+Claude: "Here's what I found from your activity:
+- Merged PR #120: fix login timeout
+- Opened PR #125: feat: add OAuth flow
+- Reviewed PR #123 (approved), PR #456 (changes requested)
+- 5 commits in backend-api
+- [From Claude Code] Fix authentication timeout bug
+- [From Claude Code] Implement OAuth flow
+- [From Claude Code] Research payment providers
+
+Anything else you worked on yesterday that I missed?"
+User: "No, that covers it"
+
+Claude: "What will you work on today?"
+User: "Continue the OAuth feature and deploy to staging"
+
+Claude: "Any blockers?"
+User: "No"
+
+Claude: "Any topic to bring up at the end of the daily?"
+User: "Yes, I want to discuss the architecture of the new payments module"
+
+[Claude generates update]
+```
+
+## Output Example
+
+```markdown
+# Daily Update - 2026-01-22
+
+## Yesterday
+- Worked on authentication feature
+- Research on payment providers
+- Merged PR #120 (fix: login timeout)
+- Opened PR #125 (feat: add OAuth flow)
+
+## Today
+- Continue OAuth feature
+- Deploy to staging
+
+## Blockers
+- No blockers
+
+## PRs & Reviews
+- **Opened:** PR #125 - feat: add OAuth flow
+- **Merged:** PR #120 - fix: login timeout
+- **Reviews:** PR #123 (approved), PR #456 (changes requested)
+
+## Topics for Discussion
+- Architecture of the new payments module
+
+---
+*Links:*
+- https://github.com/org/repo/pull/125
+- https://github.com/org/repo/pull/120
+```

--- a/skills/database-schema-designer/SKILL.md
+++ b/skills/database-schema-designer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: database-schema-designer
-description: Design robust, scalable database schemas for SQL and NoSQL databases. Provides normalization guidelines, indexing strategies, migration patterns, constraint design, and performance optimization. Ensures data integrity, query performance, and maintainable data models.
+description: Design robust, scalable database schemas for SQL and NoSQL databases. Provides normalization guidelines, indexing strategies, migration patterns, constraint design, and performance optimization for PostgreSQL, MySQL, SQLite, and MongoDB. Use when the user asks to design tables, plan a database structure, create an ERD or entity-relationship model, define foreign keys, normalize data, plan migrations, or optimize query performance.
 license: MIT
 ---
 
@@ -54,21 +54,6 @@ CREATE TABLE orders (
 | `model data` | "model data for real-time analytics" |
 | `I need a database` | "I need a database for tracking orders" |
 | `design NoSQL` | "design NoSQL schema for product catalog" |
-
----
-
-## Key Terms
-
-| Term | Definition |
-|------|------------|
-| **Normalization** | Organizing data to reduce redundancy (1NF → 2NF → 3NF) |
-| **3NF** | Third Normal Form - no transitive dependencies between columns |
-| **OLTP** | Online Transaction Processing - write-heavy, needs normalization |
-| **OLAP** | Online Analytical Processing - read-heavy, benefits from denormalization |
-| **Foreign Key (FK)** | Column that references another table's primary key |
-| **Index** | Data structure that speeds up queries (at cost of slower writes) |
-| **Access Pattern** | How your app reads/writes data (queries, joins, filters) |
-| **Denormalization** | Intentionally duplicating data to speed up reads |
 
 ---
 

--- a/skills/dependency-updater/SKILL.md
+++ b/skills/dependency-updater/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependency-updater
-description: Smart dependency management for any language. Auto-detects project type, applies safe updates automatically, prompts for major versions, diagnoses and fixes dependency issues.
+description: Smart dependency management for any language. Auto-detects project type, applies safe updates automatically, prompts for major versions, diagnoses and fixes dependency issues. Use when updating packages, resolving version conflicts, running npm/pip/cargo/go outdated checks, upgrading dependencies in package.json, requirements.txt, go.mod, or Cargo.toml, or auditing for vulnerabilities.
 license: MIT
 metadata:
   version: 1.0.0
@@ -248,33 +248,7 @@ go mod tidy
 
 ---
 
-## Security Audit
-
-Run security checks for any project:
-
-```bash
-# Node.js
-npm audit
-npm audit --json | jq '.metadata.vulnerabilities'
-
-# Python
-pip-audit
-safety check
-
-# Go
-govulncheck ./...
-
-# Rust
-cargo audit
-
-# Ruby
-bundle audit
-
-# .NET
-dotnet list package --vulnerable
-```
-
-### Severity Response
+## Severity Response
 
 | Severity | Action |
 |----------|--------|
@@ -381,43 +355,6 @@ Some packages have frequent major bumps but are backward-compatible:
 </details>
 
 <details>
-<summary><strong>Deep Dive: Version Strategies</strong></summary>
-
-### Semantic Versioning
-
-```
-MAJOR.MINOR.PATCH (e.g., 2.3.1)
-
-MAJOR: Breaking changes - requires code changes
-MINOR: New features - backward compatible
-PATCH: Bug fixes - backward compatible
-```
-
-### Range Specifiers
-
-| Specifier | Meaning | Example |
-|-----------|---------|---------|
-| `^1.2.3` | Minor + Patch OK | `>=1.2.3 <2.0.0` |
-| `~1.2.3` | Patch only | `>=1.2.3 <1.3.0` |
-| `1.2.3` | Exact (fixed) | Only `1.2.3` |
-| `>=1.2.3` | At least | Any `>=1.2.3` |
-| `*` | Any | Latest (dangerous) |
-
-### Recommended Strategy
-
-```json
-{
-  "dependencies": {
-    "critical-lib": "1.2.3",      // Exact for critical
-    "stable-lib": "~1.2.3",       // Patch only for stable
-    "modern-lib": "^1.2.3"        // Minor OK for active
-  }
-}
-```
-
-</details>
-
-<details>
 <summary><strong>Deep Dive: Conflict Resolution</strong></summary>
 
 ### Node.js Conflicts
@@ -480,12 +417,3 @@ pip install -c constraints.txt -r requirements.txt
 
 ---
 
-## Related Tools
-
-| Tool | Language | Purpose |
-|------|----------|---------|
-| [taze](https://github.com/antfu-collective/taze) | Node.js | Smart dependency updates |
-| [npm-check-updates](https://github.com/raineorshine/npm-check-updates) | Node.js | Alternative to taze |
-| [pip-review](https://github.com/jgonggrijp/pip-review) | Python | Interactive pip updates |
-| [cargo-edit](https://github.com/killercup/cargo-edit) | Rust | Cargo dependency management |
-| [bundler-audit](https://github.com/rubysec/bundler-audit) | Ruby | Security auditing |

--- a/skills/design-system-starter/SKILL.md
+++ b/skills/design-system-starter/SKILL.md
@@ -1,603 +1,104 @@
 ---
 name: design-system-starter
-description: Create and evolve design systems with design tokens, component architecture, accessibility guidelines, and documentation templates. Ensures consistent, scalable, and accessible UI across products.
+description: "Create and evolve design systems with design tokens, component architecture, theming, and WCAG-compliant accessibility patterns for front-end UI projects. Use when the user asks to build a design system, UI kit, style guide, component library, theme system, brand guidelines, or set up design tokens, dark mode, or consistent UI across products."
 license: MIT
 metadata:
   version: 1.0.0
-  tags: [design-system, ui, components, design-tokens, accessibility, frontend]
+  tags: "design-system, ui, components, design-tokens, accessibility, frontend"
 ---
 
 # Design System Starter
 
 Build robust, scalable design systems that ensure visual consistency and exceptional user experiences.
 
----
-
-## Quick Start
-
-Just describe what you need:
-
-```
-Create a design system for my React app with dark mode support
-```
-
-That's it. The skill provides tokens, components, and accessibility guidelines.
-
----
-
 ## Triggers
 
 | Trigger | Example |
 |---------|---------|
-| Create design system | "Create a design system for my app" |
-| Design tokens | "Set up design tokens for colors and spacing" |
-| Component architecture | "Design component structure using atomic design" |
-| Accessibility | "Ensure WCAG 2.1 compliance for my components" |
-| Dark mode | "Implement theming with dark mode support" |
-
----
+| Create design system / UI kit / style guide | "Create a design system for my app" |
+| Design tokens / theme setup | "Set up design tokens for colors and spacing" |
+| Component library / component architecture | "Design component structure using atomic design" |
+| Accessibility / WCAG compliance | "Ensure WCAG 2.1 compliance for my components" |
+| Dark mode / theming | "Implement theming with dark mode support" |
+| Brand guidelines / style consistency | "Set up brand guidelines for consistent UI" |
 
 ## Quick Reference
 
 | Task | Output |
 |------|--------|
-| Design tokens | Color, typography, spacing, shadows JSON |
+| Design tokens | Color, typography, spacing, shadows in W3C token format |
 | Component structure | Atomic design hierarchy (atoms, molecules, organisms) |
-| Theming | CSS variables or ThemeProvider setup |
-| Accessibility | WCAG 2.1 AA compliant patterns |
+| Theming | CSS variables, Tailwind dark mode, or ThemeProvider setup |
+| Accessibility | WCAG 2.1 AA compliant patterns with keyboard and ARIA support |
 | Documentation | Component docs with props, examples, a11y notes |
-
----
 
 ## Bundled Resources
 
-- `references/component-examples.md` - Complete component implementations
-- `templates/design-tokens-template.json` - W3C design token format
-- `templates/component-template.tsx` - React component template
-- `checklists/design-system-checklist.md` - Design system audit checklist
+- `references/component-examples.md` — Complete component implementations (Button, FormField, Card, Modal, polymorphic patterns)
+- `templates/design-tokens-template.json` — W3C design token format with color, typography, spacing, shadows
+- `templates/component-template.tsx` — React component template with TypeScript props and a11y
+- `checklists/design-system-checklist.md` — Design system audit checklist
 
----
+## Workflow
 
-## Design System Philosophy
+### 1. Define Design Tokens
 
-### What is a Design System?
+Establish foundational tokens for colors, typography, spacing, border-radius, and shadows. Use a three-tier token architecture:
 
-A design system is more than a component library—it's a collection of:
+- **Primitive tokens**: Raw values (e.g., `blue.600: "#2563eb"`)
+- **Semantic tokens**: Contextual meaning referencing primitives (e.g., `brand.primary: "{color.primitive.blue.600}"`)
+- **Component tokens**: Component-specific values referencing semantic tokens (e.g., `button.padding-x: "{spacing.4}"`)
 
-1. **Design Tokens**: Foundational design decisions (colors, spacing, typography)
-2. **Components**: Reusable UI building blocks
-3. **Patterns**: Common UX solutions and compositions
-4. **Guidelines**: Rules, principles, and best practices
-5. **Documentation**: How to use everything effectively
+See `templates/design-tokens-template.json` for the complete W3C token format with all categories.
 
-### Core Principles
+**Validation**: Run a contrast checker on all text/background color combinations. WCAG 2.1 AA requires 4.5:1 for normal text, 3:1 for large text and UI components.
 
-**1. Consistency Over Creativity**
-- Predictable patterns reduce cognitive load
-- Users learn once, apply everywhere
-- Designers and developers speak the same language
+### 2. Build Components (Atomic Design)
 
-**2. Accessible by Default**
-- WCAG 2.1 Level AA compliance minimum
-- Keyboard navigation built-in
-- Screen reader support from the start
+Follow the atomic design hierarchy: **Atoms** → **Molecules** → **Organisms** → **Templates** → **Pages**
 
-**3. Scalable and Maintainable**
-- Design tokens enable global changes
-- Component composition reduces duplication
-- Versioning and deprecation strategies
+Start with atoms (Button, Input, Label, Icon, Badge, Avatar), then compose into molecules (SearchBar, FormField, Card) and organisms (Navigation, Modal Dialog).
 
-**4. Developer-Friendly**
-- Clear API contracts
-- Comprehensive documentation
-- Easy to integrate and customize
+Key API design principles:
+- Use consistent prop names across components (`variant`, `size`)
+- Provide sensible defaults (variant defaults to `primary`, size to `md`)
+- Prefer composition over configuration (use `<Card.Header>` not `header="..."` props)
+- Support polymorphic rendering (`<Button as="a" href="/login">`)
 
----
+See `references/component-examples.md` for complete implementations with TypeScript interfaces.
 
-## Design Tokens
+### 3. Implement Theming
 
-Design tokens are the atomic design decisions that define your system's visual language.
+Choose a theming approach based on the project stack:
+- **CSS Variables**: Set `:root` tokens, override with `[data-theme="dark"]`
+- **Tailwind CSS**: Use `dark:` prefix utilities
+- **Styled Components**: Use `ThemeProvider` with light/dark theme objects
 
-### Token Categories
+See `references/component-examples.md` for implementation examples of each approach.
 
-#### 1. Color Tokens
+### 4. Ensure Accessibility
 
-**Primitive Colors** (Raw values):
-```json
-{
-  "color": {
-    "primitive": {
-      "blue": {
-        "50": "#eff6ff",
-        "100": "#dbeafe",
-        "200": "#bfdbfe",
-        "300": "#93c5fd",
-        "400": "#60a5fa",
-        "500": "#3b82f6",
-        "600": "#2563eb",
-        "700": "#1d4ed8",
-        "800": "#1e40af",
-        "900": "#1e3a8a",
-        "950": "#172554"
-      }
-    }
-  }
-}
-```
+Every component must meet WCAG 2.1 Level AA:
+- Use semantic HTML (`<button>`, `<nav>`, `<main>`) — no div/span for interactive elements
+- Build in keyboard navigation and focus management (focus traps for modals)
+- Apply ARIA attributes: `aria-label`, `aria-expanded`, `aria-controls`, `aria-live`
 
-**Semantic Colors** (Contextual meaning):
-```json
-{
-  "color": {
-    "semantic": {
-      "brand": {
-        "primary": "{color.primitive.blue.600}",
-        "primary-hover": "{color.primitive.blue.700}",
-        "primary-active": "{color.primitive.blue.800}"
-      },
-      "text": {
-        "primary": "{color.primitive.gray.900}",
-        "secondary": "{color.primitive.gray.600}",
-        "tertiary": "{color.primitive.gray.500}",
-        "disabled": "{color.primitive.gray.400}",
-        "inverse": "{color.primitive.white}"
-      },
-      "background": {
-        "primary": "{color.primitive.white}",
-        "secondary": "{color.primitive.gray.50}",
-        "tertiary": "{color.primitive.gray.100}"
-      },
-      "feedback": {
-        "success": "{color.primitive.green.600}",
-        "warning": "{color.primitive.yellow.600}",
-        "error": "{color.primitive.red.600}",
-        "info": "{color.primitive.blue.600}"
-      }
-    }
-  }
-}
-```
+See `references/component-examples.md` for accessibility patterns including Skip Links and focus traps.
 
-**Accessibility**: Ensure color contrast ratios meet WCAG 2.1 Level AA:
-- Normal text: 4.5:1 minimum
-- Large text (18pt+ or 14pt+ bold): 3:1 minimum
-- UI components and graphics: 3:1 minimum
+### 5. Document and Ship
 
-#### 2. Typography Tokens
+Each component needs: purpose, usage example, variants, props table, accessibility notes, and code examples. Use Storybook or Docusaurus for interactive documentation.
 
-```json
-{
-  "typography": {
-    "fontFamily": {
-      "sans": "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-      "serif": "'Georgia', 'Times New Roman', serif",
-      "mono": "'Fira Code', 'Courier New', monospace"
-    },
-    "fontSize": {
-      "xs": "0.75rem",     // 12px
-      "sm": "0.875rem",    // 14px
-      "base": "1rem",      // 16px
-      "lg": "1.125rem",    // 18px
-      "xl": "1.25rem",     // 20px
-      "2xl": "1.5rem",     // 24px
-      "3xl": "1.875rem",   // 30px
-      "4xl": "2.25rem",    // 36px
-      "5xl": "3rem"        // 48px
-    },
-    "fontWeight": {
-      "normal": 400,
-      "medium": 500,
-      "semibold": 600,
-      "bold": 700
-    },
-    "lineHeight": {
-      "tight": 1.25,
-      "normal": 1.5,
-      "relaxed": 1.75,
-      "loose": 2
-    },
-    "letterSpacing": {
-      "tight": "-0.025em",
-      "normal": "0",
-      "wide": "0.025em"
-    }
-  }
-}
-```
+See `templates/component-template.tsx` for the standard component documentation structure.
 
-#### 3. Spacing Tokens
+**Validation**: Verify every component has keyboard support, screen reader labels, and documented props before shipping.
 
-**Scale**: Use a consistent spacing scale (commonly 4px or 8px base)
+## Checklist
 
-```json
-{
-  "spacing": {
-    "0": "0",
-    "1": "0.25rem",   // 4px
-    "2": "0.5rem",    // 8px
-    "3": "0.75rem",   // 12px
-    "4": "1rem",      // 16px
-    "5": "1.25rem",   // 20px
-    "6": "1.5rem",    // 24px
-    "8": "2rem",      // 32px
-    "10": "2.5rem",   // 40px
-    "12": "3rem",     // 48px
-    "16": "4rem",     // 64px
-    "20": "5rem",     // 80px
-    "24": "6rem"      // 96px
-  }
-}
-```
-
-**Component-Specific Spacing**:
-```json
-{
-  "component": {
-    "button": {
-      "padding-x": "{spacing.4}",
-      "padding-y": "{spacing.2}",
-      "gap": "{spacing.2}"
-    },
-    "card": {
-      "padding": "{spacing.6}",
-      "gap": "{spacing.4}"
-    }
-  }
-}
-```
-
-#### 4. Border Radius Tokens
-
-```json
-{
-  "borderRadius": {
-    "none": "0",
-    "sm": "0.125rem",   // 2px
-    "base": "0.25rem",  // 4px
-    "md": "0.375rem",   // 6px
-    "lg": "0.5rem",     // 8px
-    "xl": "0.75rem",    // 12px
-    "2xl": "1rem",      // 16px
-    "full": "9999px"
-  }
-}
-```
-
-#### 5. Shadow Tokens
-
-```json
-{
-  "shadow": {
-    "xs": "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
-    "sm": "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)",
-    "base": "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)",
-    "md": "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
-    "lg": "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1)",
-    "xl": "0 25px 50px -12px rgba(0, 0, 0, 0.25)"
-  }
-}
-```
-
----
-
-## Component Architecture
-
-### Atomic Design Methodology
-
-**Atoms** → **Molecules** → **Organisms** → **Templates** → **Pages**
-
-#### Atoms (Primitive Components)
-Basic building blocks that can't be broken down further.
-
-**Examples:**
-- Button
-- Input
-- Label
-- Icon
-- Badge
-- Avatar
-
-**Button Component:**
-```typescript
-interface ButtonProps {
-  variant?: 'primary' | 'secondary' | 'outline' | 'ghost';
-  size?: 'sm' | 'md' | 'lg';
-  disabled?: boolean;
-  loading?: boolean;
-  icon?: React.ReactNode;
-  children: React.ReactNode;
-}
-```
-
-See `references/component-examples.md` for complete Button implementation with variants, sizes, and styling patterns.
-
-#### Molecules (Simple Compositions)
-Groups of atoms that function together.
-
-**Examples:**
-- SearchBar (Input + Button)
-- FormField (Label + Input + ErrorMessage)
-- Card (Container + Title + Content + Actions)
-
-**FormField Molecule:**
-```typescript
-interface FormFieldProps {
-  label: string;
-  name: string;
-  error?: string;
-  hint?: string;
-  required?: boolean;
-  children: React.ReactNode;
-}
-```
-
-See `references/component-examples.md` for FormField, Card (compound component pattern), Input with variants, Modal, and more composition examples.
-
-#### Organisms (Complex Compositions)
-Complex UI components made of molecules and atoms.
-
-**Examples:**
-- Navigation Bar
-- Product Card Grid
-- User Profile Section
-- Modal Dialog
-
-#### Templates (Page Layouts)
-Page-level structures that define content placement.
-
-**Examples:**
-- Dashboard Layout (Sidebar + Header + Main Content)
-- Marketing Page Layout (Hero + Features + Footer)
-- Settings Page Layout (Tabs + Content Panels)
-
-#### Pages (Specific Instances)
-Actual pages with real content.
-
----
-
-## Component API Design
-
-### Props Best Practices
-
-**1. Predictable Prop Names**
-```typescript
-// ✅ Good: Consistent naming
-<Button variant="primary" size="md" />
-<Input variant="outlined" size="md" />
-
-// ❌ Bad: Inconsistent
-<Button type="primary" sizeMode="md" />
-<Input style="outlined" inputSize="md" />
-```
-
-**2. Sensible Defaults**
-```typescript
-// ✅ Good: Provides defaults
-interface ButtonProps {
-  variant?: 'primary' | 'secondary';  // Default: primary
-  size?: 'sm' | 'md' | 'lg';          // Default: md
-}
-
-// ❌ Bad: Everything required
-interface ButtonProps {
-  variant: 'primary' | 'secondary';
-  size: 'sm' | 'md' | 'lg';
-  color: string;
-  padding: string;
-}
-```
-
-**3. Composition Over Configuration**
-```typescript
-// ✅ Good: Composable
-<Card>
-  <Card.Header>
-    <Card.Title>Title</Card.Title>
-  </Card.Header>
-  <Card.Body>Content</Card.Body>
-  <Card.Footer>Actions</Card.Footer>
-</Card>
-
-// ❌ Bad: Too many props
-<Card
-  title="Title"
-  content="Content"
-  footerContent="Actions"
-  hasHeader={true}
-  hasFooter={true}
-/>
-```
-
-**4. Polymorphic Components**
-Allow components to render as different HTML elements:
-```typescript
-<Button as="a" href="/login">Login</Button>
-<Button as="button" onClick={handleClick}>Click Me</Button>
-```
-
-See `references/component-examples.md` for complete polymorphic component TypeScript patterns.
-
----
-
-## Theming and Dark Mode
-
-### Theme Structure
-
-```typescript
-interface Theme {
-  colors: {
-    brand: {
-      primary: string;
-      secondary: string;
-    };
-    text: {
-      primary: string;
-      secondary: string;
-    };
-    background: {
-      primary: string;
-      secondary: string;
-    };
-    feedback: {
-      success: string;
-      warning: string;
-      error: string;
-      info: string;
-    };
-  };
-  typography: {
-    fontFamily: {
-      sans: string;
-      mono: string;
-    };
-    fontSize: Record<string, string>;
-  };
-  spacing: Record<string, string>;
-  borderRadius: Record<string, string>;
-  shadow: Record<string, string>;
-}
-```
-
-### Dark Mode Implementation
-
-**Approach 1: CSS Variables**
-```css
-:root {
-  --color-bg-primary: #ffffff;
-  --color-text-primary: #000000;
-}
-
-[data-theme="dark"] {
-  --color-bg-primary: #1a1a1a;
-  --color-text-primary: #ffffff;
-}
-```
-
-**Approach 2: Tailwind CSS Dark Mode**
-```tsx
-<div className="bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
-  Content
-</div>
-```
-
-**Approach 3: Styled Components ThemeProvider**
-```typescript
-const lightTheme = { background: '#fff', text: '#000' };
-const darkTheme = { background: '#000', text: '#fff' };
-
-<ThemeProvider theme={isDark ? darkTheme : lightTheme}>
-  <App />
-</ThemeProvider>
-```
-
----
-
-## Accessibility Guidelines
-
-### WCAG 2.1 Level AA Compliance
-
-#### Color Contrast
-- **Normal text** (< 18pt): 4.5:1 minimum
-- **Large text** (≥ 18pt or ≥ 14pt bold): 3:1 minimum
-- **UI components**: 3:1 minimum
-
-**Tools**: Use contrast checkers like [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
-
-#### Keyboard Navigation
-```typescript
-// ✅ All interactive elements must be keyboard accessible
-<button
-  onClick={handleClick}
-  onKeyDown={(e) => e.key === 'Enter' && handleClick()}
->
-  Click me
-</button>
-
-// ✅ Focus management
-<Modal>
-  <FocusTrap>
-    {/* Modal content */}
-  </FocusTrap>
-</Modal>
-```
-
-#### ARIA Attributes
-Essential ARIA patterns:
-- `aria-label`: Provide accessible names
-- `aria-expanded`: Communicate expanded/collapsed state
-- `aria-controls`: Associate controls with content
-- `aria-live`: Announce dynamic content changes
-
-#### Screen Reader Support
-- Use semantic HTML elements (`<button>`, `<nav>`, `<main>`)
-- Avoid div/span soup for interactive elements
-- Provide meaningful labels for all controls
-
-See `references/component-examples.md` for complete accessibility examples including Skip Links, focus traps, and ARIA patterns.
-
----
-
-## Documentation Standards
-
-### Component Documentation Template
-
-Each component should document:
-- **Purpose**: What the component does
-- **Usage**: Import statement and basic example
-- **Variants**: Available visual styles
-- **Props**: Complete prop table with types, defaults, descriptions
-- **Accessibility**: Keyboard support, ARIA attributes, screen reader behavior
-- **Examples**: Common use cases with code
-
-Use Storybook, Docusaurus, or similar tools for interactive documentation.
-
-See `templates/component-template.tsx` for the standard component structure.
-
----
-
-## Design System Workflow
-
-### 1. Design Phase
-- **Audit existing patterns**: Identify inconsistencies
-- **Define design tokens**: Colors, typography, spacing
-- **Create component inventory**: List all needed components
-- **Design in Figma**: Create component library
-
-### 2. Development Phase
-- **Set up tooling**: Storybook, TypeScript, testing
-- **Implement tokens**: CSS variables or theme config
-- **Build atoms first**: Start with primitives
-- **Compose upward**: Build molecules, organisms
-- **Document as you go**: Write docs alongside code
-
-### 3. Adoption Phase
-- **Create migration guide**: Help teams adopt
-- **Provide codemods**: Automate migrations when possible
-- **Run workshops**: Train teams on usage
-- **Gather feedback**: Iterate based on real usage
-
-### 4. Maintenance Phase
-- **Version semantically**: Major/minor/patch releases
-- **Deprecation strategy**: Phase out old components gracefully
-- **Changelog**: Document all changes
-- **Monitor adoption**: Track usage across products
-
----
-
-## Quick Start Checklist
-
-When creating a new design system:
-
-- [ ] Define design principles and values
-- [ ] Establish design token structure (colors, typography, spacing)
-- [ ] Create primitive color palette (50-950 scale)
-- [ ] Define semantic color tokens (brand, text, background, feedback)
-- [ ] Set typography scale and font families
-- [ ] Establish spacing scale (4px or 8px base)
-- [ ] Design atomic components (Button, Input, Label, etc.)
-- [ ] Implement theming system (light/dark mode)
-- [ ] Ensure WCAG 2.1 Level AA compliance
-- [ ] Set up documentation (Storybook or similar)
-- [ ] Create usage examples for each component
+- [ ] Define design token structure (primitives → semantic → component)
+- [ ] Validate all color contrast ratios meet WCAG 2.1 AA
+- [ ] Build atomic components with consistent prop APIs
+- [ ] Implement theming system with dark mode support
+- [ ] Add keyboard navigation and ARIA attributes to all interactive components
+- [ ] Document each component with props, examples, and a11y notes
 - [ ] Establish versioning and release strategy
-- [ ] Create migration guides for adopting teams

--- a/skills/difficult-workplace-conversations/SKILL.md
+++ b/skills/difficult-workplace-conversations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: difficult-workplace-conversations
-description: Structured approach to workplace conflicts, performance discussions, and challenging feedback using preparation-delivery-followup framework. Use when preparing for tough conversations, addressing conflicts, giving critical feedback, or navigating sensitive workplace discussions.
+description: Draft talking points, create conversation openers, and generate follow-up action plans for workplace conflicts, performance discussions, and challenging feedback using a preparation-delivery-followup framework. Use when preparing for tough conversations, addressing conflicts, giving critical feedback, or navigating sensitive workplace discussions.
 allowed-tools: Read, Glob, Grep
 ---
 
@@ -89,30 +89,15 @@ Difficult conversations succeed or fail based on three phases:
    - Rebuild trust over time
    - Watch for regression
 
-## Key Principles
-
-### Separate Impact from Intent
-
-**What happened:** Observable behavior
-**What I felt:** Your emotional response
-**What I assume:** Their intention (often wrong)
-
-Focus conversation on behavior and impact, not assumed intentions.
+## Key Frameworks
 
 ### The SBI Model
 
+Use this structure for all feedback delivery:
+
 **Situation:** When and where did this happen?
-**Behavior:** What specifically did they do/say?
+**Behavior:** What specifically did they do/say? (observable facts, not interpretation)
 **Impact:** What was the effect on you, the team, or the work?
-
-### Managing Emotions
-
-| If You Feel | Before Acting |
-| ----------- | ------------- |
-| Angry | Wait 24 hours, write but don't send |
-| Hurt | Talk to neutral party first |
-| Anxious | Practice the conversation |
-| Defensive | Identify your contribution |
 
 ### When to Escalate
 

--- a/skills/domain-name-brainstormer/SKILL.md
+++ b/skills/domain-name-brainstormer/SKILL.md
@@ -1,212 +1,71 @@
 ---
 name: domain-name-brainstormer
-description: Generates creative domain name ideas for your project and checks availability across multiple TLDs (.com, .io, .dev, .ai, etc.). Saves hours of brainstorming and manual checking.
+description: Generates creative domain name suggestions and checks availability across TLDs (.com, .io, .dev, .ai, .app, .co). Use when the user asks to brainstorm domain names, find a website name, search for available domains, register a domain, pick a name for a new project, startup, product, or personal brand.
 ---
 
 # Domain Name Brainstormer
 
-This skill helps you find the perfect domain name for your project by generating creative options and checking what's actually available to register.
+Generate creative, brandable domain name ideas and check availability across multiple TLDs for projects, startups, products, and personal brands.
 
-## When to Use This Skill
+## Workflow
 
-- Starting a new project or company
-- Launching a product or service
-- Creating a personal brand or portfolio site
-- Rebranding an existing project
-- Registering a domain for a side project
-- Finding available alternatives when your first choice is taken
+1. **Gather context**: Ask the user about the project purpose, target audience, preferred keywords, and any TLD preferences
+2. **Generate candidates**: Produce 10-15 domain name ideas using these strategies:
+   - Combine relevant keywords (e.g., "code" + "clip" = codeclip)
+   - Use portmanteaus, abbreviations, or invented words
+   - Keep names short (<15 chars), pronounceable, no hyphens
+   - Consider industry conventions (e.g., .dev/.io for developer tools, .ai for ML products)
+3. **Check availability**: For each candidate, check availability across requested TLDs using `whois` or DNS lookup:
+   ```bash
+   # Quick availability check via whois
+   whois example.com | grep -i "no match\|not found\|available"
+   # Alternative: DNS-based check
+   dig +short example.com
+   ```
+4. **Rank and present**: Present results grouped by availability, with a top pick and runner-up including reasoning
+5. **Iterate**: If top choices are taken, generate variations (prefixes, suffixes, alternate TLDs) and re-check
 
-## What This Skill Does
+## Output Format
 
-1. **Understands Your Project**: Analyzes what you're building and who it's for
-2. **Generates Creative Names**: Creates relevant, memorable domain options
-3. **Checks Availability**: Verifies which domains are actually available across multiple TLDs
-4. **Multiple Extensions**: Suggests .com, .io, .dev, .ai, .app, and more
-5. **Provides Alternatives**: Offers variations if top choices are taken
-6. **Branding Insights**: Explains why certain names work well
-
-## How to Use
-
-### Basic Brainstorming
-
-```
-I'm building a project management tool for remote teams. 
-Suggest domain names.
-```
+Present results using this structure:
 
 ```
-Help me brainstorm domain names for a personal finance app
+## Available Domains
+1. snippetbox.com - Directly describes the product, easy to remember
+2. snippet.dev - .dev extension signals developer tool, short
+
+## Taken / Premium
+- codeshare.com (taken)
+- snippets.com (premium)
+
+## Top Pick: snippet.dev
+- Short, memorable, audience-appropriate TLD
+
+## Next Steps
+- Register your preferred choice
+- Want me to check more variations or alternative keywords?
 ```
 
-### Specific Preferences
+## Examples
 
-```
-I need a domain name for my AI writing assistant. 
-Prefer short names with .ai or .io extension.
-```
+**Basic request**: "Suggest domain names for a project management tool for remote teams"
+- Generate: teamflow.com, remotedesk.io, taskpulse.dev, asyncwork.com, etc.
 
-### With Keywords
+**With constraints**: "I need a short .ai domain for my writing assistant"
+- Focus on: writly.ai, prosecraft.ai, draftai.ai, etc.
 
-```
-Suggest domain names using the words "pixel" or "studio" 
-for my design agency
-```
+**Keyword-based**: "Use 'pixel' or 'studio' for my design agency"
+- Generate: pixelstudio.com, studiopixel.design, pixelcraft.io, etc.
 
-## Example
+**Personal brand**: "Domain for my name John Smith, software engineer"
+- Generate: johnsmith.dev, jsmith.io, smithcode.com, etc.
 
-**User**: "I'm building a tool for developers to share code snippets. Suggest creative domain names."
+## Validation Checklist
 
-**Output**:
-```
-Analyzing your project...
-Target audience: Developers
-Key features: Code sharing, snippets, collaboration
-
-🎯 Domain Name Suggestions
-
-## Available (.com)
-1. ✓ snippetbox.com - Clear, memorable, available!
-   Why: Directly describes the product, easy to remember
-
-2. ✓ codeclip.com - Short and snappy
-   Why: Implies quick code sharing, only 8 characters
-
-3. ✓ devpaste.com - Developer-focused
-   Why: Familiar to devs (like pastebin), clear purpose
-
-## Available (Alternative TLDs)
-4. ✓ snippet.dev - Perfect extension for developers
-   Why: .dev extension signals developer tool
-
-5. ✓ codebox.io - Tech-forward
-   Why: .io popular with tech startups, clean name
-
-6. ✓ sharecode.app - Descriptive
-   Why: .app extension, clearly states the action
-
-## Premium/Taken (.com)
-- codeshare.com (Taken, est. $2,500)
-- snippets.com (Taken, premium domain)
-
-## Recommendations
-
-🏆 Top Pick: snippet.dev
-- Perfect for developer audience
-- Short and memorable  
-- .dev extension adds credibility
-- Available now!
-
-🥈 Runner-up: snippetbox.com
-- .com is universally recognized
-- Slightly longer but descriptive
-- Great brandability
-
-Next steps:
-1. Register your favorite before someone else does!
-2. Want me to check more variations?
-3. Need help with logo ideas for these names?
-```
-
-**Inspired by:** Ben Aiad's use case from Lenny's Newsletter
-
-## Domain Naming Tips
-
-### What Makes a Good Domain
-
-✓ **Short**: Under 15 characters ideal
-✓ **Memorable**: Easy to recall and spell
-✓ **Pronounceable**: Can be said in conversation
-✓ **Descriptive**: Hints at what you do
-✓ **Brandable**: Unique enough to stand out
-✓ **No hyphens**: Easier to share verbally
-
-### TLD Guide
-
-- **.com**: Universal, trusted, great for businesses
-- **.io**: Tech startups, developer tools
-- **.dev**: Developer-focused products
-- **.ai**: AI/ML products
-- **.app**: Mobile or web applications
-- **.co**: Alternative to .com
-- **.xyz**: Modern, creative projects
-- **.design**: Creative/design agencies
-- **.tech**: Technology companies
-
-## Advanced Features
-
-### Check Similar Variations
-
-```
-Check availability for "codebase" and similar variations 
-across .com, .io, .dev
-```
-
-### Industry-Specific
-
-```
-Suggest domain names for a sustainable fashion brand, 
-checking .eco and .fashion TLDs
-```
-
-### Multilingual Options
-
-```
-Brainstorm domain names in English and Spanish for 
-a language learning app
-```
-
-### Competitor Analysis
-
-```
-Show me domain patterns used by successful project 
-management tools, then suggest similar available ones
-```
-
-## Example Workflows
-
-### Startup Launch
-1. Describe your startup idea
-2. Get 10-15 domain suggestions across TLDs
-3. Review availability and pricing
-4. Pick top 3 favorites
-5. Register immediately
-
-### Personal Brand
-1. Share your name and profession
-2. Get variations (firstname.com, firstnamelastname.dev, etc.)
-3. Check social media handle availability too
-4. Register consistent brand across platforms
-
-### Product Naming
-1. Describe product and target market
-2. Get creative, brandable names
-3. Check trademark conflicts
-4. Verify domain and social availability
-5. Test names with target audience
-
-## Tips for Success
-
-1. **Act Fast**: Good domains get taken quickly
-2. **Register Variations**: Get .com and .io to protect brand
-3. **Avoid Numbers**: Hard to communicate verbally
-4. **Check Social Media**: Make sure @username is available too
-5. **Say It Out Loud**: Test if it's easy to pronounce
-6. **Check Trademarks**: Ensure no legal conflicts
-7. **Think Long-term**: Will it still make sense in 5 years?
-
-## Pricing Context
-
-When suggesting domains, I'll note:
-- Standard domains: ~$10-15/year
-- Premium TLDs (.io, .ai): ~$30-50/year
-- Taken domains: Market price if listed
-- Premium domains: $hundreds to $thousands
-
-## Related Tools
-
-After picking a domain:
-- Check logo design options
-- Verify social media handles
-- Research trademark availability
-- Plan brand identity colors/fonts
+Before presenting final suggestions, verify each name is:
+- [ ] Under 15 characters
+- [ ] Easy to spell and pronounce
+- [ ] Free of trademark conflicts (search USPTO if uncertain)
+- [ ] Available on the checked TLD
+- [ ] Not easily confused with established brands
 

--- a/skills/excalidraw/SKILL.md
+++ b/skills/excalidraw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: excalidraw
-description: "Use when working with *.excalidraw or *.excalidraw.json files, user mentions diagrams/flowcharts, or requests architecture visualization - delegates all Excalidraw operations to subagents to prevent context exhaustion from verbose JSON (single files: 4k-22k tokens, can exceed read limits)"
+description: "Create, read, modify, and compare Excalidraw diagrams via subagent delegation. Use when working with *.excalidraw or *.excalidraw.json files, user mentions diagrams/flowcharts, or requests architecture visualization. Delegates all operations to subagents to prevent context exhaustion from verbose JSON (single files: 4k-22k tokens, can exceed read limits)."
 ---
 
 # Excalidraw Subagent Delegation
@@ -121,30 +121,16 @@ Return:
 - DO NOT return full element details from both files
 ```
 
-## Common Rationalizations (STOP and Delegate Instead)
+## Avoid These Patterns — Always Delegate Instead
 
-| Excuse | Reality | What to Do |
-|--------|---------|------------|
-| "Direct reading is most efficient" | Consumes 4k-22k tokens unnecessarily | Delegate to subagent |
-| "It's token-efficient to read directly" | Baseline tests showed 9-45% budget used | Always delegate |
-| "This is optimal for one-time analysis" | "One-time" still pollutes main context | Subagent isolation |
-| "The JSON is straightforward" | Simplicity ≠ token efficiency | Delegate anyway |
-| "I need to understand the format" | Format understanding not needed in main agent | Subagent handles format |
-| "Within reasonable bounds" (18k tokens) | "Reasonable" is subjective rationalization | Hard rule: delegate |
-| "Just a quick check of components" | "Quick check" still loads full JSON | Extract text via subagent |
-| "File is small (16K)" | 4k tokens is NOT small | Size threshold doesn't matter |
+If you catch yourself about to do any of these, **stop and delegate to a subagent**:
 
-## Red Flags - STOP and Delegate
-
-Catch yourself about to:
-- Use Read tool on .excalidraw file
-- "Quickly check" what components exist
-- "Understand the structure" before modifying
-- Load file to "see what's there"
-- Compare multiple diagrams side-by-side
+- Read an .excalidraw file directly ("just a quick check", "small file", "straightforward JSON")
+- "Understand the format" or "see what's there" before modifying
+- Compare multiple diagrams side-by-side in main context
 - Parse JSON to "extract just the text"
 
-**All of these mean: Use Task tool with subagent instead.**
+The problem is verbosity, not complexity. Even simple Excalidraw JSON consumes 4k-22k tokens because each element has 20+ properties (positioning, styling, roughness) — only text labels and relationships matter (~10% of content). Token cost comes from volume, not complexity.
 
 ## Quick Reference
 
@@ -190,32 +176,6 @@ Task: Extract and explain components in .ryanquinn3/ticketing/detailed-architect
 [Responds to user with architecture explanation, main context preserved]
 ```
 
-## Why "Straightforward JSON" Doesn't Matter
-
-Agents often rationalize: "The format is simple, I can just read it."
-
-**The problem isn't complexity - it's verbosity:**
-- Simple structure with 20+ properties per element
-- Repetitive metadata (seed, version, nonce, roughness)
-- Positioning data (x, y, width, height) not semantically useful
-- Visual styling (strokeColor, opacity, fillStyle) irrelevant to content
-
-**Token cost comes from volume, not complexity.**
-
-Even "straightforward" JSON consumes 4k-22k tokens because:
-- 79 elements × ~280 tokens/element = 22k tokens
-- Most tokens are metadata noise
-- Only text labels and relationships matter (~10% of content)
-
 ## The Iron Law
 
-**Main agents NEVER read Excalidraw files. No exceptions.**
-
-Not for:
-- "Quick checks"
-- "Small files"
-- "Understanding format"
-- "One-time analysis"
-- "Optimal efficiency"
-
-**Always delegate. Isolation is free via subagents.**
+**Main agents NEVER read Excalidraw files. No exceptions. Always delegate to subagents.**

--- a/skills/frontend-to-backend-requirements/SKILL.md
+++ b/skills/frontend-to-backend-requirements/SKILL.md
@@ -1,28 +1,14 @@
 ---
 name: frontend-to-backend-requirements
-description: Document frontend data needs for backend developers. Use when frontend needs to communicate API requirements to backend, or user says 'backend requirements', 'what data do I need', 'API requirements', or is describing data needs for a UI.
+description: Generate structured backend requirement documents that capture frontend data needs, UI states, and business rules as collaborative requests. Use when frontend needs to communicate API requirements to backend, user says 'backend requirements', 'what data do I need', 'API requirements', or is describing data needs for a UI. Outputs a requirements markdown file per feature.
 ---
 
 # Backend Requirements Mode
 
-You are a frontend developer documenting what data you need from backend. You describe the **what**, not the **how**. Backend owns implementation details.
+You are a frontend developer generating a structured requirements document that captures what data you need from backend. You describe the **what**, not the **how**. Backend owns implementation details.
 
 > **No Chat Output**: ALL responses go to `.claude/docs/ai/<feature-name>/backend-requirements.md`
 > **No Implementation Details**: Don't specify endpoints, field names, or API structure—that's backend's call.
-
----
-
-## The Point
-
-This mode is for frontend devs to communicate data needs:
-- What data do I need to render this screen?
-- What actions should the user be able to perform?
-- What business rules affect the UI?
-- What states and errors should I handle?
-
-**You're requesting, not demanding.** Backend may push back, suggest alternatives, or ask clarifying questions. That's healthy collaboration.
-
----
 
 ## What You Own vs. What Backend Owns
 
@@ -33,8 +19,6 @@ This mode is for frontend devs to communicate data needs:
 | UI states to handle | Field names, types |
 | User-facing validation | API conventions |
 | Display requirements | Performance/caching |
-
----
 
 ## Workflow
 
@@ -64,23 +48,16 @@ For each screen/component, describe:
 - Loading, empty, error, success
 - Edge cases (partial data, expired, etc.)
 
-### Step 3: Surface Uncertainties
+### Step 3: Surface Uncertainties and Invite Discussion
 
-List what you're unsure about:
+List what you're unsure about, then end with open questions that invite backend collaboration:
+
 - Business rules you don't fully understand
 - Edge cases you're not sure how to handle
 - Places where you're guessing
+- Questions like "Would it make sense to...?", "Should I expect...?", "Is there a simpler way to...?"
 
-**These invite backend to clarify or push back.**
-
-### Step 4: Leave Room for Discussion
-
-End with open questions:
-- "Would it make sense to...?"
-- "Should I expect...?"
-- "Is there a simpler way to...?"
-
----
+Frame uncertainties as invitations: "Push back if this complicates things unnecessarily" or "Open to suggestions on a better approach."
 
 ## Output Format
 
@@ -133,61 +110,24 @@ Create `.claude/docs/ai/<feature-name>/backend-requirements.md`:
 [Backend responses, decisions made, changes to requirements]
 ```
 
----
+## Examples
 
-## Good vs. Bad Requests
-
-### Bad (Dictating Implementation)
+**Bad** — Dictating implementation:
 > "I need a GET /api/contracts endpoint that returns an array with fields: id, title, status, created_at"
 
-### Good (Describing Needs)
-> "I need to show a list of contracts. Each item shows the contract title, its current status, and when it was created. User should be able to filter by status."
+**Good** — Describing needs with context:
+> "On the dashboard, there's a 'Recent Contracts' widget showing the 5 most recent contracts. Each item shows the contract title, its current status, and when it was created. User should be able to filter by status and clicks one to go to detail page."
 
-### Bad (Assuming Structure)
+**Bad** — Assuming structure:
 > "The provider object should be nested inside the contract response"
 
-### Good (Describing Relationship)
+**Good** — Describing the relationship:
 > "For each contract, I need to show who the provider is (their name and maybe logo)"
-
-### Bad (No Context)
-> "I need contract data"
-
-### Good (With Context)
-> "On the dashboard, there's a 'Recent Contracts' widget showing the 5 most recent contracts. User clicks one to go to detail page."
-
----
-
-## Encouraging Pushback
-
-Include these prompts in your requirements:
-
-- "Let me know if this doesn't make sense for how the data is structured"
-- "Open to suggestions on a better approach"
-- "Not sure if this is the right way to think about it"
-- "Push back if this complicates things unnecessarily"
-
-**Good collaboration = frontend describes the problem, backend proposes the solution.**
-
----
 
 ## Rules
 
-- **NO IMPLEMENTATION DETAILS**—don't specify endpoints, methods, field names
-- **DESCRIBE, DON'T PRESCRIBE**—say what you need, not how to provide it
-- **INCLUDE CONTEXT**—why you need it helps backend make better choices
-- **SURFACE UNKNOWNS**—don't hide confusion, invite clarification
-- **INVITE PUSHBACK**—explicitly ask for backend's input
-- **UPDATE THE DOC**—add backend responses to Discussion Log
-- **STAY HUMBLE**—you're asking, not demanding
-
----
-
-## After Backend Responds
-
-Update the requirements doc:
-1. Add responses to Discussion Log
-2. Adjust requirements based on feedback
-3. Mark resolved uncertainties
-4. Note any decisions made
-
-The doc becomes the source of truth for what was agreed.
+- **DESCRIBE, DON'T PRESCRIBE** — say what you need, not how to provide it. No endpoints, methods, or field names.
+- **INCLUDE CONTEXT** — why you need it helps backend make better choices
+- **SURFACE UNKNOWNS** — don't hide confusion, invite clarification
+- **INVITE PUSHBACK** — explicitly ask for backend's input
+- **UPDATE THE DOC** — when backend responds, add to Discussion Log, adjust requirements, mark resolved uncertainties, and note decisions made. The doc becomes the source of truth.

--- a/skills/game-changing-features/CATEGORIES.md
+++ b/skills/game-changing-features/CATEGORIES.md
@@ -1,0 +1,16 @@
+# Idea Categories Reference
+
+Force yourself through each category when brainstorming:
+
+| Category | Question | Example |
+|----------|----------|---------|
+| **Speed** | What takes too long? | Instant search, predictive loading |
+| **Automation** | What's repetitive? | Auto-scheduling, smart defaults |
+| **Intelligence** | What could be smarter? | Recommendations, anomaly detection |
+| **Integration** | What else do users use? | Calendar sync, export options |
+| **Collaboration** | How do users work together? | Sharing, comments, real-time |
+| **Personalization** | How is everyone different? | Custom views, preferences |
+| **Visibility** | What's hidden that shouldn't be? | Dashboards, progress tracking |
+| **Confidence** | What creates anxiety? | Confirmations, undo, previews |
+| **Delight** | What could spark joy? | Animations, celebrations, polish |
+| **Access** | Who can't use this yet? | Mobile, offline, accessibility |

--- a/skills/game-changing-features/SKILL.md
+++ b/skills/game-changing-features/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: game-changing-features
-description: Find 10x product opportunities and high-leverage improvements. Use when user wants strategic product thinking, mentions '10x', wants to find high-impact features, or says 'what would make this 10x better', 'product strategy', or 'what should we build next'.
+description: Analyze user pain points, identify leverage points, and generate prioritized feature recommendations using first-principles product strategy. Use when user wants strategic product thinking, mentions '10x', wants to find high-impact features, or says 'what would make this 10x better', 'product strategy', 'what should we build next', or 'find game-changing features'.
 ---
 
 # 10x Mode
@@ -9,16 +9,6 @@ You are a product strategist with founder mentality. We're not here to add featu
 
 > **No Chat Output**: ALL responses go to `.claude/docs/ai/<product-or-area>/10x/session-N.md`
 > **No Code**: This is pure strategy. Implementation comes later.
-
----
-
-## The Point
-
-Most product work is incremental: fix bugs, add requested features, polish edges. That's necessary but not sufficient.
-
-This mode forces a different question: **What would make this 10x more valuable?**
-
-Not 10% better. Not "nice to have." Game-changing. The kind of thing that makes users say "how did I live without this?"
 
 ---
 
@@ -138,20 +128,7 @@ Don't just list ideas—stack rank them:
 
 ## Idea Categories to Explore
 
-Force yourself through each category:
-
-| Category | Question | Example |
-|----------|----------|---------|
-| **Speed** | What takes too long? | Instant search, predictive loading |
-| **Automation** | What's repetitive? | Auto-scheduling, smart defaults |
-| **Intelligence** | What could be smarter? | Recommendations, anomaly detection |
-| **Integration** | What else do users use? | Calendar sync, export options |
-| **Collaboration** | How do users work together? | Sharing, comments, real-time |
-| **Personalization** | How is everyone different? | Custom views, preferences |
-| **Visibility** | What's hidden that shouldn't be? | Dashboards, progress tracking |
-| **Confidence** | What creates anxiety? | Confirmations, undo, previews |
-| **Delight** | What could spark joy? | Animations, celebrations, polish |
-| **Access** | Who can't use this yet? | Mobile, offline, accessibility |
+For a full brainstorming checklist across 10 categories (Speed, Automation, Intelligence, Integration, Collaboration, Personalization, Visibility, Confidence, Delight, Access), see [CATEGORIES.md](./CATEGORIES.md).
 
 ---
 
@@ -239,26 +216,16 @@ What would make this 10x more valuable?
 
 ## Rules
 
-- **THINK BIG FIRST**—don't self-censor with "that's too hard." Capture the idea, evaluate later.
-- **SMALL CAN BE HUGE**—don't dismiss simple ideas. Sometimes one button changes everything.
-- **USER VALUE, NOT FEATURE COUNT**—10 features that add 1% each ≠ 1 feature that adds 10x.
-- **BE SPECIFIC**—"better UX" is not an idea. "One-click rescheduling from notification" is.
-- **QUESTION ASSUMPTIONS**—"users want X" may be wrong. What do they actually need?
-- **COMPOUND THINKING**—prefer features that get better over time.
-- **NO SAFE IDEAS**—if every idea is "obviously good," you're not thinking hard enough.
-- **CITE EVIDENCE**—if you saw something in the codebase or research, reference it.
+- **Think big, evaluate later** — capture ambitious ideas first, assess feasibility second.
+- **Small can be huge** — one button can change everything; don't dismiss simple ideas.
+- **Value over volume** — one 10x feature beats ten 1% improvements.
+- **Be specific** — "better UX" is not an idea; "one-click rescheduling from notification" is.
+- **Question assumptions** — "users want X" may be wrong; find what they actually need.
+- **Prefer compounding** — features that get better over time build moats.
+- **Cite evidence** — reference codebase findings and research to ground proposals.
 
 ---
 
-## Prompts to Unstick Thinking
+## Unstick Prompts
 
-If stuck, ask yourself:
-
-- "What would make a user tell their friend about this?"
-- "What's the thing users do every day that's slightly annoying?"
-- "What would we build if we had 10x the engineering team? 1/10th?"
-- "What would a competitor need to build to beat us?"
-- "What do power users do manually that we could make native?"
-- "What's the insight we have from data that users don't see?"
-- "What would make this addictive (in a good way)?"
-- "What's the feature that sounds crazy but might work?"
+If stuck, ask: "What would make a user tell their friend?", "What's slightly annoying every day?", "What would we build with 10x the team? 1/10th?", "What do power users do manually that we could make native?", "What's the feature that sounds crazy but might work?"

--- a/skills/gemini/SKILL.md
+++ b/skills/gemini/SKILL.md
@@ -1,223 +1,135 @@
 ---
 name: gemini
-description: Use when the user asks to run Gemini CLI for code review, plan review, or big context (>200k) processing. Ideal for comprehensive analysis requiring large context windows. Uses Gemini 3 Pro by default for state-of-the-art reasoning and coding.
+description: "Use when the user asks to run Gemini, review code with an external LLM, analyze large files or codebases (>200k tokens), summarize lengthy documents, or process big context. Delegates to Gemini CLI for code review, plan review, multi-file analysis, codebase summarization, and large-document processing. Defaults to Gemini 3 Pro."
 ---
 
 # Gemini Skill Guide
 
-## When to Use Gemini
-- WHEN ASKED TO BE ACTIVATED
-- **Code Review**: Comprehensive code reviews across multiple files
-- **Plan Review**: Analyzing architectural plans, technical specifications, or project roadmaps
-- **Big Context Processing**: Tasks requiring >200k tokens of context (entire codebases, documentation sets)
-- **Multi-file Analysis**: Understanding relationships and patterns across many files
+## When to Use
 
-## ⚠️ Critical: Background/Non-Interactive Mode Warning
+- User explicitly asks to run Gemini or use an external model
+- **Code review** across multiple files or an entire repository
+- **Plan review** of architectural specs, technical designs, or roadmaps
+- **Large-context processing** requiring >200k tokens (full codebases, documentation sets, extensive logs)
+- **Multi-file analysis** to find patterns, dependencies, or technical debt
+- **Document summarization** of lengthy files or large document collections
 
-**NEVER use `--approval-mode default` in background or non-interactive shells** (like Claude Code tool calls). It will hang indefinitely waiting for approval prompts that cannot be provided.
+## Background Mode Rule
 
-**For automated/background reviews:**
-- ✅ Use `--approval-mode yolo` for fully automated execution
-- ✅ OR wrap with timeout: `timeout 300 gemini ...`
-- ❌ NEVER use `--approval-mode default` without interactive terminal
+**NEVER use `--approval-mode default` in non-interactive shells** (Claude Code tool calls, CI/CD). It hangs waiting for approval prompts.
 
-**Symptoms of hung Gemini:**
-- Process running 20+ minutes with 0% CPU usage
-- No network activity
-- Process state shows 'S' (sleeping)
+- Use `--approval-mode yolo` (or `-y`) for all background/automated tasks
+- Optionally wrap with `timeout 300 gemini ...` for safety
+- Reserve `--approval-mode default` for interactive terminal sessions only
 
-**Fix hung process:**
-```bash
-# Check if hung
-ps aux | grep gemini | grep -v grep
+If a Gemini process hangs (20+ min, 0% CPU, sleeping state): `pkill -9 -f "gemini.*gemini-3"`
 
-# Kill if necessary
-pkill -9 -f "gemini.*gemini-3-pro-preview"
-```
+## Workflow
 
-## Running a Task
+### 1. Choose a Model
 
-1. Ask the user (via `AskUserQuestion`) which model to use in a **single prompt**. Available models:
-   - `gemini-3-pro-preview` ⭐ (flagship model, best for coding & complex reasoning, 35% better at software engineering than 2.5 Pro)
-   - `gemini-3-flash` (sub-second latency, distilled from 3 Pro, best for speed-critical tasks)
-   - `gemini-2.5-pro` (legacy option, strong all-around performance)
-   - `gemini-2.5-flash` (legacy option, cost-efficient with thinking capabilities)
-   - `gemini-2.5-flash-lite` (legacy option, fastest processing)
+Ask the user via `AskUserQuestion` which model to use:
 
-2. Select the approval mode based on the task:
-   - `default`: Prompt for approval (⚠️ ONLY for interactive terminal sessions)
-   - `auto_edit`: Auto-approve edit tools only (for code reviews with suggestions)
-   - `yolo`: Auto-approve all tools (✅ REQUIRED for background/automated tasks)
-
-3. Assemble the command with appropriate options:
-   - `-m, --model <MODEL>` - Model selection
-   - `--approval-mode <default|auto_edit|yolo>` - Control tool approval
-   - `-y, --yolo` - Alternative to `--approval-mode yolo`
-   - `-i, --prompt-interactive "prompt"` - Execute prompt and continue interactively
-   - `--include-directories <DIR>` - Additional directories to include in workspace
-   - `-s, --sandbox` - Run in sandbox mode for isolation
-
-4. **For background/automated tasks, ALWAYS use `--approval-mode yolo`** or add timeout wrapper. NEVER use `default` in non-interactive shells.
-
-5. Run the command and capture the output. For background/automated mode:
-   ```bash
-   # Recommended: Use yolo for background tasks
-   gemini -m gemini-3-pro-preview --approval-mode yolo "Review this codebase for security issues"
-
-   # Or with timeout (5 min limit)
-   timeout 300 gemini -m gemini-3-pro-preview --approval-mode yolo "Review this codebase"
-   ```
-
-6. For interactive sessions with an initial prompt:
-   ```bash
-   gemini -m gemini-3-pro-preview -i "Review the authentication system" --approval-mode auto_edit
-   ```
-
-7. **After Gemini completes**, inform the user: "The Gemini analysis is complete. You can start a new Gemini session for follow-up analysis or continue exploring the findings."
-
-### Quick Reference
-
-| Use case | Approval mode | Key flags |
-| --- | --- | --- |
-| Background code review | `yolo` ✅ | `-m gemini-3-pro-preview --approval-mode yolo` |
-| Background analysis | `yolo` ✅ | `-m gemini-3-pro-preview --approval-mode yolo` |
-| Background with timeout | `yolo` ✅ | `timeout 300 gemini -m gemini-3-pro-preview --approval-mode yolo` |
-| Interactive code review | `default` | `-m gemini-3-pro-preview --approval-mode default` (interactive terminal only) |
-| Code review with auto-edits | `auto_edit` | `-m gemini-3-pro-preview --approval-mode auto_edit` |
-| Automated refactoring | `yolo` | `-m gemini-3-pro-preview --approval-mode yolo` |
-| Speed-critical background | `yolo` ✅ | `-m gemini-3-flash --approval-mode yolo` |
-| Cost-optimized background | `yolo` ✅ | `-m gemini-2.5-flash --approval-mode yolo` |
-| Multi-directory analysis | `yolo` (if background) | `--include-directories <DIR1> --include-directories <DIR2>` |
-| Interactive with prompt | `auto_edit` or `default` | `-i "prompt" --approval-mode <mode>` |
-
-### Model Selection Guide
-
-| Model | Best for | Context window | Key features |
+| Model | Best for | Context | Notes |
 | --- | --- | --- | --- |
-| `gemini-3-pro-preview` ⭐ | **Flagship model**: Complex reasoning, coding, agentic tasks | 1M input / 64k output | Vibe coding, 76.2% SWE-bench, $2-4/M input |
-| `gemini-3-flash` | Sub-second latency, speed-critical applications | 1M input / 64k output | Distilled from 3 Pro, TPU-optimized |
-| `gemini-2.5-pro` | Legacy: Strong all-around performance | 1M input / 65k output | Thinking mode, mature stability |
-| `gemini-2.5-flash` | Legacy: Cost-efficient, high-volume tasks | 1M input / 65k output | Best price ($0.15/M), thinking mode |
-| `gemini-2.5-flash-lite` | Legacy: Fastest processing, high throughput | 1M input / 65k output | Maximum speed, minimal latency |
+| `gemini-3-pro-preview` | Complex reasoning, coding, agentic tasks | 1M in / 64k out | Default. 76.2% SWE-bench, $2-4/M input |
+| `gemini-3-flash` | Speed-critical, sub-second latency | 1M in / 64k out | Distilled from 3 Pro |
+| `gemini-2.5-pro` | Legacy all-around performance | 1M in / 65k out | Mature, stable |
+| `gemini-2.5-flash` | Cost-optimized high-volume tasks | 1M in / 65k out | $0.15/M input |
+| `gemini-2.5-flash-lite` | Maximum throughput | 1M in / 65k out | Fastest latency |
 
-**Gemini 3 Advantages**: 35% higher accuracy in software engineering, state-of-the-art on SWE-bench (76.2%), GPQA Diamond (91.9%), and WebDev Arena (1487 Elo). Knowledge cutoff: January 2025.
+### 2. Select Approval Mode
 
-**Coming Soon**: `gemini-3-deep-think` for ultra-complex reasoning with enhanced thinking capabilities.
+| Mode | When to use |
+| --- | --- |
+| `yolo` | Background/automated tasks (required for non-interactive shells) |
+| `auto_edit` | Interactive code review with auto-applied suggestions |
+| `default` | Interactive terminal only — never in background |
 
-## Common Use Cases
+### 3. Run the Command
 
-### Code Review (Background/Automated)
+**Key flags:**
+- `-m, --model <MODEL>` — model selection
+- `--approval-mode <mode>` — control tool approval
+- `-y, --yolo` — shorthand for `--approval-mode yolo`
+- `-i, --prompt-interactive "prompt"` — start interactive session with initial prompt
+- `--include-directories <DIR>` — add directories to workspace scope
+- `-s, --sandbox` — run in isolation
+
+Before using `--approval-mode yolo`, `-y`, or `--sandbox`, ask the user for permission via `AskUserQuestion` unless already granted.
+
+### 4. Verify and Follow Up
+
+- Inform the user when Gemini completes
+- Use `AskUserQuestion` to confirm next steps
+- For follow-ups, start a new session with context from prior findings
+
+## Examples
+
+### Background Code Review
 ```bash
-# For background execution (Claude Code, CI/CD, etc.)
 gemini -m gemini-3-pro-preview --approval-mode yolo \
   "Perform a comprehensive code review focusing on:
    1. Security vulnerabilities
    2. Performance issues
    3. Code quality and maintainability
    4. Best practices violations"
+```
 
-# With timeout safety (5 minutes)
+### Background Plan Review
+```bash
+gemini -m gemini-3-pro-preview --approval-mode yolo \
+  "Review this architectural plan for scalability concerns, missing components, integration challenges, and alternative approaches"
+```
+
+### Large Codebase Analysis with Timeout
+```bash
 timeout 300 gemini -m gemini-3-pro-preview --approval-mode yolo \
-  "Perform a comprehensive code review..."
+  "Analyze the entire codebase: overall architecture, key patterns, technical debt, and refactoring opportunities"
 ```
 
-### Plan Review (Background/Automated)
+### Interactive Review (Terminal Only)
 ```bash
-# For background execution
+gemini -m gemini-3-pro-preview -i "Review the authentication system" --approval-mode auto_edit
+```
+
+### Multi-Directory Analysis
+```bash
 gemini -m gemini-3-pro-preview --approval-mode yolo \
-  "Review this architectural plan for:
-   1. Scalability concerns
-   2. Missing components
-   3. Integration challenges
-   4. Alternative approaches"
+  --include-directories ../shared-lib --include-directories ../api \
+  "Analyze cross-module dependencies and integration patterns"
 ```
-
-### Big Context Analysis (Background/Automated)
-```bash
-# For background execution
-gemini -m gemini-3-pro-preview --approval-mode yolo \
-  "Analyze the entire codebase to understand:
-   1. Overall architecture
-   2. Key patterns and conventions
-   3. Potential technical debt
-   4. Refactoring opportunities"
-```
-
-### Interactive Code Review (Terminal Only)
-```bash
-# ONLY use default mode in interactive terminal
-gemini -m gemini-3-pro-preview --approval-mode default \
-  "Review the authentication flow for security issues"
-```
-
-## Following Up
-
-- Gemini CLI sessions are typically one-shot or interactive. Unlike Codex, there's no built-in resume functionality.
-- For follow-up analysis, start a new Gemini session with context from previous findings.
-- When proposing follow-up actions, restate the chosen model and approval mode.
-- Use `AskUserQuestion` after each Gemini command to confirm next steps or gather clarifications.
 
 ## Error Handling
 
-- Stop and report failures whenever `gemini --version` or a Gemini command exits non-zero.
-- Request direction before retrying failed commands.
-- Before using high-impact flags (`--approval-mode yolo`, `-y`, `--sandbox`), ask the user for permission using `AskUserQuestion` unless already granted.
-- When output includes warnings or partial results, summarize them and ask how to adjust using `AskUserQuestion`.
+- Stop and report failures when `gemini --version` or any command exits non-zero
+- Request direction before retrying failed commands
+- Summarize warnings or partial results and ask how to adjust via `AskUserQuestion`
 
-## Troubleshooting Hung Gemini Processes
+## Troubleshooting Hung Processes
 
-### Detection
 ```bash
-# Check for hung processes
+# Detect: check for hung Gemini processes
 ps aux | grep -E "gemini.*gemini-3" | grep -v grep
 
-# Look for these symptoms:
-# - Process running 20+ minutes
-# - CPU usage at 0%
-# - Process state 'S' (sleeping)
-# - No network connections
-```
-
-### Diagnosis
-```bash
-# Get detailed process info
-ps -o pid,etime,pcpu,stat,command -p <PID>
-
-# Check network activity
+# Diagnose: check if process has network activity (0 = hung)
 lsof -p <PID> 2>/dev/null | grep -E "(TCP|ESTABLISHED)" | wc -l
-# If result is 0, process is hung
-```
 
-### Resolution
-```bash
-# Kill hung Gemini processes
+# Resolve: kill and verify
 pkill -9 -f "gemini.*gemini-3-pro-preview"
-
-# Or kill specific PID
-kill -9 <PID>
-
-# Verify cleanup
 ps aux | grep gemini | grep -v grep
 ```
 
-### Prevention
-- **ALWAYS use `--approval-mode yolo` for background/automated tasks**
-- Add timeout wrapper for safety: `timeout 300 gemini ...`
-- Never use `--approval-mode default` in non-interactive shells
-- Monitor first run with `ps` to ensure process completes
+**Prevention:** Always use `--approval-mode yolo` for background tasks. Add `timeout 300` wrapper for extra safety.
 
-## Tips for Large Context Processing
+## Tips for Large Context
 
-1. **Be specific**: Provide clear, structured prompts for what to analyze
-2. **Use include-directories**: Explicitly specify all relevant directories
-3. **Choose the right model**:
-   - Use `gemini-3-pro-preview` for complex reasoning, coding tasks, and maximum analysis quality (recommended default)
-   - Use `gemini-3-flash` for speed-critical tasks requiring sub-second response times
-   - Use `gemini-2.5-flash` for cost-optimized high-volume processing
-4. **Leverage Gemini 3's strengths**: 35% better at software engineering tasks, exceptional at agentic workflows and vibe coding
-5. **Break down complex tasks**: Even with large context, structured analysis is more effective
-6. **Save findings**: Ask Gemini to output structured reports that can be saved for reference
+1. **Be specific** — provide structured prompts listing what to analyze
+2. **Use `--include-directories`** — explicitly scope all relevant directories
+3. **Match model to task** — use 3 Pro for quality, 3 Flash for speed, 2.5 Flash for cost
+4. **Break down complex tasks** — structured analysis beats monolithic prompts
+5. **Save findings** — ask Gemini to output structured reports for reference
 
 ## CLI Version
 
-Requires Gemini CLI v0.16.0 or later for Gemini 3 model support. Check version: `gemini --version`
+Requires Gemini CLI v0.16.0+. Check with: `gemini --version`

--- a/skills/gepetto/SKILL.md
+++ b/skills/gepetto/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gepetto
-description: Creates detailed, sectionized implementation plans through research, stakeholder interviews, and multi-LLM review. Use when planning features that need thorough pre-implementation analysis.
+description: Generates implementation plans with task breakdowns, dependency graphs, and section-by-section specs through automated research, stakeholder interviews, and multi-LLM review. Use when building a technical spec, design document, project roadmap, architecture plan, or feature specification that needs thorough pre-implementation analysis before coding begins.
 ---
 
 # Gepetto
@@ -29,24 +29,13 @@ Note: GEPETTO will write many .md files to the planning directory you pass it
 
 If NO @file was provided OR the path doesn't end with `.md`, output this and STOP:
 ```
-═══════════════════════════════════════════════════════════════
 GEPETTO: Spec File Required
-═══════════════════════════════════════════════════════════════
+Requires a .md spec file. Planning directory is inferred from the spec's parent directory.
 
-This skill requires a markdown spec file path (must end with .md).
-The planning directory is inferred from the spec file's parent directory.
-
-To start a NEW plan:
-  1. Create a markdown spec file describing what you want to build
-  2. It can be as detailed or as vague as you like
-  3. Place it in a directory where gepetto can save planning files
-  4. Run: /gepetto @path/to/your-spec.md
-
-To RESUME an existing plan:
-  1. Run: /gepetto @path/to/your-spec.md
+  New plan:    Create a spec .md file, then run /gepetto @path/to/your-spec.md
+  Resume plan: Run /gepetto @path/to/your-spec.md (existing files are detected automatically)
 
 Example: /gepetto @planning/my-feature-spec.md
-═══════════════════════════════════════════════════════════════
 ```
 **Do not continue. Wait for user to re-invoke with a .md file path.**
 

--- a/skills/humanizer/SKILL.md
+++ b/skills/humanizer/SKILL.md
@@ -1,22 +1,14 @@
 ---
 name: humanizer
-version: 2.1.1
-description: |
-  Remove signs of AI-generated writing from text. Use when editing or reviewing
-  text to make it sound more natural and human-written. Based on Wikipedia's
-  comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
-  inflated symbolism, promotional language, superficial -ing analyses, vague
-  attributions, em dash overuse, rule of three, AI vocabulary words, negative
-  parallelisms, and excessive conjunctive phrases.
-
+description: >
+  Remove signs of AI-generated writing from text. Use when editing, reviewing,
+  or humanizing text to make it sound more natural and human-written. Based on
+  Wikipedia's comprehensive "Signs of AI writing" guide. Detects and fixes
+  patterns including: inflated symbolism, promotional language, superficial
+  -ing analyses, vague attributions, em dash overuse, rule of three, AI
+  vocabulary words, negative parallelisms, and excessive conjunctive phrases.
   Credits: Original skill by @blader - https://github.com/blader/humanizer
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Grep
-  - Glob
-  - AskUserQuestion
+allowed-tools: Read, Write, Edit, Grep, Glob, AskUserQuestion
 ---
 
 # Humanizer: Remove AI Writing Patterns

--- a/skills/marp-slide/SKILL.md
+++ b/skills/marp-slide/SKILL.md
@@ -1,149 +1,40 @@
 ---
 name: marp-slide
-description: Create professional Marp presentation slides with 7 beautiful themes (default, minimal, colorful, dark, gradient, tech, business). Use when users request slide creation, presentations, or Marp documents. Supports custom themes, image layouts, and "make it look good" requests with automatic quality improvements.
+description: Create professional Marp Markdown presentation slides with 7 built-in themes (default, minimal, colorful, dark, gradient, tech, business). Use when users request Marp slides, Markdown-based presentations, or Marp documents. Outputs .md files with embedded CSS themes, image layouts, and automatic quality improvements. Prefer over PowerPoint/Google Slides when user wants Markdown-native, version-controllable presentations.
 ---
 
 # Marp Slide Creator
 
 Create professional, visually appealing Marp presentation slides with 7 pre-designed themes and built-in best practices.
 
-## When to Use This Skill
-
-Use this skill when the user:
-- Requests to create presentation slides or Marp documents
-- Asks to "make slides look good" or "improve slide design"
-- Provides vague instructions like "良い感じにして" (make it nice) or "かっこよく" (make it cool)
-- Wants to create lecture or seminar materials
-- Needs bullet-point focused slides with occasional images
-
-## Quick Start
-
-### Step 1: Select Theme
-
-First, determine the appropriate theme based on the user's request and content.
-
-**Quick theme selection:**
-- **Technical/Developer content** → tech theme
-- **Business/Corporate** → business theme
-- **Creative/Event** → colorful or gradient theme
-- **Academic/Simple** → minimal theme
-- **General/Unsure** → default theme
-- **Dark background preferred** → dark or tech theme
-
-For detailed theme selection guidance, read `references/theme-selection.md`.
-
-### Step 2: Create Slides
-
-1. **Read relevant references first**:
-   - Always start by reading `references/marp-syntax.md` for basic syntax
-   - For images: `references/image-patterns.md` (official Marpit image syntax)
-   - For advanced features (math, emoji): `references/advanced-features.md`
-   - For custom themes: `references/theme-css-guide.md`
-
-2. Copy content from the appropriate template file:
-   - `assets/template-basic.md` - Default theme (most common)
-   - `assets/template-minimal.md` - Minimal theme
-   - `assets/template-colorful.md` - Colorful theme
-   - `assets/template-dark.md` - Dark mode theme
-   - `assets/template-gradient.md` - Gradient theme
-   - `assets/template-tech.md` - Tech/code theme
-   - `assets/template-business.md` - Business theme
-
-3. Read `references/best-practices.md` for quality guidelines
-
-4. Structure content following best practices:
-   - Title slide with `<!-- _class: lead -->`
-   - Concise h2 titles (5-7 characters in Japanese)
-   - 3-5 bullet points per slide
-   - Adequate whitespace
-
-5. Add images if needed using patterns from `references/image-patterns.md`
-
-6. Save to `/mnt/user-data/outputs/` with `.md` extension
-
 ## Available Themes
 
-### 1. Default Theme
-**Colors**: Beige background, navy text, blue headings
-**Style**: Clean, sophisticated with decorative lines
-**Use for**: General seminars, lectures, presentations
-**Template**: `template-basic.md`
+| Theme | Template | Best For |
+|-------|----------|----------|
+| Default | `template-basic.md` | General seminars, lectures |
+| Minimal | `template-minimal.md` | Academic, content-focused |
+| Colorful | `template-colorful.md` | Creative events, youth |
+| Dark | `template-dark.md` | Tech talks, evening events |
+| Gradient | `template-gradient.md` | Visual-focused, creative |
+| Tech | `template-tech.md` | Dev tutorials, tech meetups |
+| Business | `template-business.md` | Corporate, proposals |
 
-### 2. Minimal Theme
-**Colors**: White background, gray text, black headings
-**Style**: Minimal decoration, wide margins, light fonts
-**Use for**: Content-focused presentations, academic talks
-**Template**: `template-minimal.md`
+For detailed theme colors, styles, and selection guidance, read `references/theme-selection.md`.
 
-### 3. Colorful & Pop Theme
-**Colors**: Pink gradient background, multi-color accents
-**Style**: Vibrant gradients, bold fonts, rainbow accents
-**Use for**: Youth-oriented events, creative projects
-**Template**: `template-colorful.md`
+## Workflow
 
-### 4. Dark Mode Theme
-**Colors**: Black background, cyan/purple accents
-**Style**: Dark theme with glow effects, eye-friendly
-**Use for**: Tech presentations, evening talks, modern look
-**Template**: `template-dark.md`
+1. **Understand requirements** - Identify content, target audience, and formality level
+2. **Select theme** - Match content type to theme (see quick selection below); if uncertain, consult `references/theme-selection.md`; default to Default theme
+3. **Read references** - Always start with `references/marp-syntax.md`; add `references/image-patterns.md` for images, `references/advanced-features.md` for math/emoji, `references/theme-css-guide.md` for custom themes
+4. **Apply template** - Copy from appropriate `assets/template-*.md` file (CSS is already embedded)
+5. **Structure content** - Title slide with `<!-- _class: lead -->` + h1; content slides with h2 + 3-5 bullet points; keep titles concise (5-7 chars in Japanese); keep text to 15-25 chars per line
+6. **Add images** - Use Marp syntax: `![bg right:40%](image.png)` for side images, `![bg](image.png)` for full background
+7. **Validate** - Run through the Quality Checklist below before delivering
+8. **Output** - Save to `/mnt/user-data/outputs/` with descriptive `.md` filename
 
-### 5. Gradient Background Theme
-**Colors**: Purple/pink/blue/green gradients (varies per slide)
-**Style**: Different gradient per slide, white text, shadows
-**Use for**: Visual-focused, creative presentations
-**Template**: `template-gradient.md`
-
-### 6. Tech/Code Theme
-**Colors**: GitHub-style dark background, blue/green accents
-**Style**: Code fonts, Markdown-style headers with # symbols
-**Use for**: Programming tutorials, tech meetups, developer content
-**Template**: `template-tech.md`
-
-### 7. Business Theme
-**Colors**: White background, navy headings, blue accents
-**Style**: Corporate presentation style, top border, table support
-**Use for**: Business presentations, proposals, reports
-**Template**: `template-business.md`
-
-## Creating Slides Process
-
-### Basic Workflow
-
-1. **Understand requirements**
-   - Identify content: title, topics, key points
-   - Determine target audience
-   - Assess formality level
-
-2. **Select theme**
-   - Use quick selection rules above
-   - If uncertain, consult `references/theme-selection.md`
-   - Default to default theme if still unsure
-
-3. **Apply template**
-   - Load appropriate template from `assets/`
-   - CSS is already embedded - no external files needed
-   - Maintain template structure
-
-4. **Structure content**
-   - Title slide: `<!-- _class: lead -->` + h1
-   - Content slides: h2 title + bullet points
-   - Keep titles to 5-7 characters (Japanese)
-   - Use 3-5 bullet points per slide
-
-5. **Refine quality**
-   - Read `references/best-practices.md`
-   - Ensure adequate whitespace
-   - Maintain consistency
-   - Keep text concise (15-25 chars per line)
-
-6. **Add images**
-   - If needed, consult `references/image-patterns.md`
-   - Common: `![bg right:40%](image.png)` for side images
-   - Use proper Marp image syntax
-
-7. **Output file**
-   - Save to `/mnt/user-data/outputs/`
-   - Use descriptive filename like `presentation.md`
+**Quick theme selection:**
+- **Technical/Developer** → tech | **Business/Corporate** → business | **Creative/Event** → colorful or gradient
+- **Academic/Simple** → minimal | **General/Unsure** → default | **Dark background** → dark or tech
 
 ## Handling "Make It Look Good" Requests
 
@@ -191,13 +82,6 @@ Example lecture pattern:
 - Explanation point 2
 - Explanation point 3
 ```
-
-## File Output
-
-Always save the final Marp file to `/mnt/user-data/outputs/` with `.md` extension:
-- `presentation.md`
-- `seminar-slides.md`
-- `lecture-materials.md`
 
 ## Quality Checklist
 

--- a/skills/naming-analyzer/SKILL.md
+++ b/skills/naming-analyzer/SKILL.md
@@ -1,97 +1,76 @@
 ---
 name: naming-analyzer
-description: Suggest better variable, function, and class names based on context and conventions.
+description: Analyzes code to recommend descriptive, convention-compliant names for variables, functions, classes, and identifiers. Use when the user asks to rename variables, improve identifier names, review naming conventions, find a better name for something, or fix inconsistent naming patterns across a codebase.
 ---
 
-# Naming Analyzer Skill
+# Naming Analyzer
 
-Suggest better variable, function, and class names based on context and conventions.
+Analyze code context to suggest clearer, more descriptive, convention-compliant names for variables, functions, classes, constants, and other identifiers.
 
-## Instructions
+## Workflow
 
-You are a naming convention expert. When invoked:
-
-1. **Analyze Existing Names**:
+1. **Scan identifiers** in the target file or directory:
    - Variables, constants, functions, methods
    - Classes, interfaces, types
-   - Files and directories
-   - Database tables and columns
-   - API endpoints
+   - Files, directories, database columns, API endpoints
 
-2. **Identify Issues**:
-   - Unclear or vague names
-   - Abbreviations that obscure meaning
-   - Inconsistent naming conventions
-   - Misleading names (name doesn't match behavior)
-   - Too short or too long names
-   - Hungarian notation misuse
-   - Single-letter variables outside loops
+2. **Detect naming issues** by checking each identifier against these categories:
+   - **Misleading**: name does not match actual behavior (e.g., `getUser` that mutates state)
+   - **Vague**: generic names like `data`, `info`, `temp`, `process`
+   - **Abbreviated**: unclear shorthand like `usrCfg`, `calcTtl`
+   - **Convention violation**: wrong casing for the language or missing boolean prefix
+   - **Inconsistent**: mixed conventions within the same project
 
-3. **Check Conventions**:
-   - Language-specific conventions (camelCase, snake_case, PascalCase)
-   - Framework conventions (React components, Vue props)
-   - Project-specific patterns
-   - Industry standards
+3. **Resolve language conventions** for the target codebase:
+   - **JS/TS**: `camelCase` vars/functions, `PascalCase` classes, `UPPER_SNAKE_CASE` constants, `is/has/can/should` boolean prefixes
+   - **Python**: `snake_case` vars/functions, `PascalCase` classes, `UPPER_SNAKE_CASE` constants, `is_/has_/can_` boolean prefixes
+   - **Java**: `camelCase` vars/methods, `PascalCase` classes, `UPPER_SNAKE_CASE` constants, `lowercase` packages
+   - **Go**: `PascalCase` exported, `camelCase` unexported, all-caps acronyms (`HTTPServer`)
 
-4. **Provide Suggestions**:
-   - Better alternative names
-   - Reasoning for each suggestion
-   - Consistency improvements
-   - Contextual appropriateness
+4. **Generate rename suggestions** with reasoning for each:
+   - Provide the current name, suggested name, and why
+   - Classify severity: Critical (misleading) > Major (vague/unclear) > Minor (convention)
 
-## Naming Conventions by Language
+5. **Validate renames** before applying:
+   - Check for naming conflicts with existing identifiers in scope
+   - Verify all references (imports, call sites) would be updated
+   - Confirm renames do not break tests — run the project test suite after applying changes
+   - Use IDE-safe rename refactoring when available
 
-### JavaScript/TypeScript
-- Variables/functions: `camelCase`
-- Classes/interfaces: `PascalCase`
-- Constants: `UPPER_SNAKE_CASE`
-- Private fields: `_prefixUnderscore` or `#privateField`
-- Boolean: `is`, `has`, `can`, `should` prefixes
+## Key Naming Principles
 
-### Python
-- Variables/functions: `snake_case`
-- Classes: `PascalCase`
-- Constants: `UPPER_SNAKE_CASE`
-- Private: `_prefix_underscore`
-- Boolean: `is_`, `has_`, `can_` prefixes
+- **Clarity over brevity**: `userConfig` not `usrCfg`, `calculateTotal` not `calcTtl`
+- **Booleans read as questions**: `isActive`, `hasPermission`, `canEdit`, `shouldRender`
+- **Functions use verb phrases**: `sendEmail()`, `parseJSON()`, `formatCurrency()`
+- **Classes use nouns**: `PaymentProcessor`, `EmailValidator` — avoid generic `Manager`/`Helper`
+- **Constants include units**: `CACHE_DURATION_MS`, `MAX_FILE_SIZE_MB`
+- **Well-known abbreviations are fine**: `html`, `api`, `url`, `id`, `http`
+- **Loop counters can be short**: `i`, `j`, `k` in small scopes
 
-### Java
-- Variables/methods: `camelCase`
-- Classes/interfaces: `PascalCase`
-- Constants: `UPPER_SNAKE_CASE`
-- Packages: `lowercase`
+## Examples
 
-### Go
-- Exported: `PascalCase`
-- Unexported: `camelCase`
-- Acronyms: All caps (`HTTPServer`, not `HttpServer`)
-
-## Common Naming Issues
-
-### Too Vague
+### Vague vs. specific names
 ```javascript
-// ❌ Bad - Too generic
+// Before
 function process(data) { }
 const info = getData();
-let temp = x;
 
-// ✓ Good - Specific and clear
+// After
 function processPayment(transaction) { }
 const userProfile = getUserProfile();
-let previousValue = x;
 ```
 
-### Misleading Names
+### Misleading names (side effects hidden by getter name)
 ```javascript
-// ❌ Bad - Name doesn't match behavior
+// Before — name implies read-only
 function getUser(id) {
   const user = fetchUser(id);
   user.lastLogin = Date.now();
-  saveUser(user); // Side effect! Not just "getting"
+  saveUser(user);
   return user;
 }
 
-// ✓ Good - Name reflects actual behavior
+// After — name reflects the mutation
 function fetchAndUpdateUserLogin(id) {
   const user = fetchUser(id);
   user.lastLogin = Date.now();
@@ -100,252 +79,38 @@ function fetchAndUpdateUserLogin(id) {
 }
 ```
 
-### Abbreviations
+### Boolean naming
 ```javascript
-// ❌ Bad - Unclear abbreviations
-const usrCfg = loadConfig();
-function calcTtl(arr) { }
-
-// ✓ Good - Clear and readable
-const userConfig = loadConfig();
-function calculateTotal(amounts) { }
-
-// ✓ Acceptable - Well-known abbreviations
-const htmlElement = document.getElementById('main');
-const apiUrl = process.env.API_URL;
-```
-
-### Boolean Naming
-```javascript
-// ❌ Bad - Unclear state
+// Before
 const login = user.authenticated;
 const status = checkUser();
 
-// ✓ Good - Clear boolean intent
+// After
 const isLoggedIn = user.authenticated;
 const isUserValid = checkUser();
 const hasPermission = user.roles.includes('admin');
-const canEditPost = isOwner || isAdmin;
-const shouldShowNotification = isEnabled && hasUnread;
-```
-
-### Magic Numbers
-```javascript
-// ❌ Bad - Unnamed constants
-if (age > 18) { }
-setTimeout(callback, 3600000);
-
-// ✓ Good - Named constants
-const LEGAL_AGE = 18;
-const ONE_HOUR_IN_MS = 60 * 60 * 1000;
-
-if (age > LEGAL_AGE) { }
-setTimeout(callback, ONE_HOUR_IN_MS);
-```
-
-## Usage Examples
-
-```
-@naming-analyzer
-@naming-analyzer src/
-@naming-analyzer UserService.js
-@naming-analyzer --conventions
-@naming-analyzer --fix-all
 ```
 
 ## Report Format
 
-```markdown
-# Naming Analysis Report
-
-## Summary
-- Items analyzed: 156
-- Issues found: 23
-- Critical: 5 (misleading names)
-- Major: 12 (unclear/vague)
-- Minor: 6 (convention violations)
-
----
-
-## Critical Issues (5)
-
-### src/services/UserService.js:45
-**Current**: `getUser(id)`
-**Issue**: Function name implies read-only but has side effects (updates lastLogin)
-**Severity**: Critical - Misleading
-**Suggestion**: `fetchAndUpdateUserLogin(id)`
-**Reason**: Name should reflect the mutation
-
-### src/utils/helpers.js:23
-**Current**: `validate(x)`
-**Issue**: Generic parameter name, unclear what's being validated
-**Severity**: Critical - Too vague
-**Suggestion**: `validateEmail(emailAddress)`
-**Reason**: Specific names improve clarity
-
----
-
-## Major Issues (12)
-
-### src/components/DataList.jsx:12
-**Current**: `const d = new Date()`
-**Issue**: Single-letter variable in large scope
-**Severity**: Major
-**Suggestion**: `const currentDate = new Date()`
-**Reason**: Clarity and searchability
-
-### src/api/client.js:67
-**Current**: `function proc(data) {}`
-**Issue**: Abbreviated function name
-**Severity**: Major
-**Suggestion**: `function processApiResponse(data) {}`
-**Reason**: Full words are more readable
-
-### src/models/User.js:34
-**Current**: `user.active`
-**Issue**: Boolean property without prefix
-**Severity**: Major
-**Suggestion**: `user.isActive`
-**Reason**: Follow boolean naming convention
-
-### src/utils/format.js:89
-**Current**: `const MAX = 100`
-**Issue**: Generic constant name
-**Severity**: Major
-**Suggestion**: `const MAX_RETRY_ATTEMPTS = 100`
-**Reason**: Specific purpose is clearer
-
----
-
-## Minor Issues (6)
-
-### src/config/settings.js:12
-**Current**: `const API_url = '...'`
-**Issue**: Inconsistent casing (mixing UPPER and lower)
-**Severity**: Minor
-**Suggestion**: `const API_URL = '...'` or `const apiUrl = '...'`
-**Reason**: Consistency in convention
-
-### src/helpers/string.js:45
-**Current**: `function strToNum(s) {}`
-**Issue**: Abbreviated function and parameter
-**Severity**: Minor
-**Suggestion**: `function stringToNumber(value) {}`
-**Reason**: Clarity over brevity
-
----
-
-## Convention Violations
-
-### Inconsistent Boolean Prefixes
-**Locations**: 8 files
-**Issue**: Mixed use of `is`, `has`, `can` vs no prefix
-**Recommendation**: Standardize on boolean prefixes
-- Use `is` for state: `isActive`, `isVisible`
-- Use `has` for possession: `hasPermission`, `hasError`
-- Use `can` for ability: `canEdit`, `canDelete`
-- Use `should` for decisions: `shouldRender`, `shouldValidate`
-
-### Mixed Naming Conventions
-**Location**: src/legacy/
-**Issue**: Mix of camelCase and snake_case in JavaScript
-**Recommendation**: Convert all to camelCase for consistency
-
----
-
-## Suggested Renaming
-
-### High Priority (Misleading or Critical)
-1. `getUser` → `fetchAndUpdateUserLogin` (src/services/UserService.js:45)
-2. `validate` → `validateEmail` (src/utils/helpers.js:23)
-3. `process` → `processPaymentTransaction` (src/payment/processor.js:67)
-
-### Medium Priority (Clarity)
-1. `d` → `currentDate` (7 locations)
-2. `temp` → `previousValue` (4 locations)
-3. `data` → `apiResponse` or more specific (12 locations)
-4. `arr` → `items`, `values`, or more specific (8 locations)
-
-### Low Priority (Convention)
-1. `active` → `isActive` (12 locations)
-2. `error` → `hasError` (6 locations)
-3. `API_url` → `API_URL` (3 locations)
-
----
-
-## Naming Patterns to Follow
-
-### Functions/Methods
-- Verbs: `get`, `set`, `create`, `update`, `delete`, `fetch`, `calculate`, `validate`
-- Clear action: `sendEmail()`, `parseJSON()`, `formatCurrency()`
-
-### Classes
-- Nouns: `UserService`, `PaymentProcessor`, `EmailValidator`
-- Avoid generic: Don't use `Manager`, `Helper`, `Utility` unless necessary
-
-### Variables
-- Nouns or noun phrases: `user`, `emailAddress`, `totalAmount`
-- Descriptive: `userList` not `list`, `activeUsers` not `users2`
-
-### Constants
-- All caps with underscores: `MAX_RETRY_ATTEMPTS`, `DEFAULT_TIMEOUT`
-- Include units: `CACHE_DURATION_MS`, `MAX_FILE_SIZE_MB`
-
-### Booleans
-- Question form: `isValid`, `hasPermission`, `canEdit`
-- Affirmative: `isEnabled` not `isDisabled` (prefer positive)
-
----
-
-## Refactoring Script
-
-Would you like me to create a refactoring script to apply these changes?
-This will:
-1. Rename all suggested items
-2. Update all references
-3. Maintain git history
-4. Generate migration guide
-
----
-
-## Best Practices
-
-✓ **DO**:
-- Use full words over abbreviations
-- Be specific and descriptive
-- Follow language conventions
-- Use consistent patterns
-- Make booleans obvious
-- Include units in constants
-
-✗ **DON'T**:
-- Use single letters (except in loops: i, j, k)
-- Use vague names (data, info, temp, x)
-- Mix naming conventions
-- Use misleading names
-- Over-abbreviate
-- Use Hungarian notation in modern code
-```
-
-## Naming Decision Tree
+Present findings as a structured report:
 
 ```
-Is it a boolean?
-├─ Yes → Use is/has/can/should prefix
-└─ No → Is it a function?
-    ├─ Yes → Use verb phrase (action)
-    └─ No → Is it a class?
-        ├─ Yes → Use noun (PascalCase)
-        └─ No → Is it a constant?
-            ├─ Yes → Use UPPER_SNAKE_CASE
-            └─ No → Use descriptive noun (camelCase/snake_case)
+## Naming Analysis — [target]
+| # | Location | Current | Suggested | Severity | Reason |
+|---|----------|---------|-----------|----------|--------|
+| 1 | file:line | `getUser` | `fetchAndUpdateUserLogin` | Critical | Hides side effects |
+| 2 | file:line | `d` | `currentDate` | Major | Single-letter in large scope |
+| 3 | file:line | `API_url` | `API_URL` | Minor | Inconsistent casing |
+
+**Summary**: X items analyzed, Y issues (Z critical, W major, V minor)
 ```
 
-## Notes
+## Decision Tree
 
-- Prioritize clarity over brevity
-- Context matters (loop counters can be `i`, `j`)
-- Well-known abbreviations are okay (`html`, `api`, `url`, `id`)
-- Consistency within a project is more important than perfect naming
-- Refactor names as understanding improves
-- Use IDE rename refactoring to safely update all references
+When choosing a name, follow this sequence:
+1. **Boolean?** Use `is/has/can/should` prefix
+2. **Function?** Use a verb phrase describing the action
+3. **Class?** Use a noun in `PascalCase`
+4. **Constant?** Use `UPPER_SNAKE_CASE` with descriptive purpose
+5. **Variable?** Use a descriptive noun phrase in the language's convention

--- a/skills/openapi-to-typescript/SKILL.md
+++ b/skills/openapi-to-typescript/SKILL.md
@@ -10,13 +10,6 @@ Converts OpenAPI 3.0 specifications to TypeScript interfaces and type guards.
 **Input:** OpenAPI file (JSON or YAML)
 **Output:** TypeScript file with interfaces and type guards
 
-## When to Use
-
-- "generate types from openapi"
-- "convert openapi to typescript"
-- "create API interfaces"
-- "generate types from spec"
-
 ## Workflow
 
 1. Request the OpenAPI file path (if not provided)
@@ -26,18 +19,12 @@ Converts OpenAPI 3.0 specifications to TypeScript interfaces and type guards.
 5. Generate TypeScript (interfaces + type guards)
 6. Ask where to save (default: `types/api.ts` in current directory)
 7. Write the file
+8. Validate output compiles: `tsc --noEmit types/api.ts` (if TypeScript is available)
+9. Report any compile errors and fix before finalizing
 
 ## OpenAPI Validation
 
-Check before processing:
-
-```
-- Field "openapi" must exist and start with "3.0"
-- Field "paths" must exist
-- Field "components.schemas" must exist (if there are types)
-```
-
-If invalid, report the error and stop.
+Before processing, verify: `openapi` field starts with `"3.0"`, `paths` exists, and `components.schemas` exists if types are expected. If invalid, report the specific error and stop.
 
 ## Type Mapping
 
@@ -53,13 +40,7 @@ If invalid, report the error and stop.
 
 ### Format Modifiers
 
-| Format        | TypeScript              |
-|---------------|-------------------------|
-| `uuid`        | `string` (comment UUID) |
-| `date`        | `string` (comment date) |
-| `date-time`   | `string` (comment ISO)  |
-| `email`       | `string` (comment email)|
-| `uri`         | `string` (comment URI)  |
+Format strings (`uuid`, `date`, `date-time`, `email`, `uri`) all map to `string` with a JSDoc comment noting the format.
 
 ### Complex Types
 
@@ -224,114 +205,34 @@ items: Product[]  // reference, not inline
 
 ## Complete Example
 
-**Input (OpenAPI):**
-```json
-{
-  "openapi": "3.0.0",
-  "components": {
-    "schemas": {
-      "User": {
-        "type": "object",
-        "properties": {
-          "id": {"type": "string", "format": "uuid"},
-          "email": {"type": "string", "format": "email"},
-          "role": {"type": "string", "enum": ["admin", "user"]}
-        },
-        "required": ["id", "email", "role"]
-      }
-    }
-  },
-  "paths": {
-    "/users/{id}": {
-      "get": {
-        "parameters": [{"name": "id", "in": "path", "required": true}],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/User"}
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
+Given a `User` schema with `id` (uuid), `email`, `role` (enum) and a `GET /users/{id}` endpoint, the generated output follows this structure:
 
-**Output (TypeScript):**
 ```typescript
-/**
- * Auto-generated from: api.openapi.json
- * Generated at: 2025-01-15T10:30:00Z
- *
- * DO NOT EDIT MANUALLY - Regenerate from OpenAPI schema
- */
-
-// ============================================================================
-// Types
-// ============================================================================
+// File header → Types (enums, interfaces) → Request/Response types → Type guards → Error types
 
 export type UserRole = "admin" | "user";
 
 export interface User {
   /** UUID */
   id: string;
-
   /** Email */
   email: string;
-
   role: UserRole;
 }
 
-// ============================================================================
-// Request/Response Types
-// ============================================================================
-
-export interface GetUserByIdRequest {
-  id: string;
-}
-
+export interface GetUserByIdRequest { id: string; }
 export type GetUserByIdResponse = User;
-
-// ============================================================================
-// Type Guards
-// ============================================================================
 
 export function isUser(value: unknown): value is User {
   return (
-    typeof value === 'object' &&
-    value !== null &&
-    'id' in value &&
-    typeof (value as any).id === 'string' &&
-    'email' in value &&
-    typeof (value as any).email === 'string' &&
-    'role' in value &&
-    ['admin', 'user'].includes((value as any).role)
+    typeof value === 'object' && value !== null &&
+    'id' in value && typeof (value as any).id === 'string' &&
+    'email' in value && typeof (value as any).email === 'string' &&
+    'role' in value && ['admin', 'user'].includes((value as any).role)
   );
 }
 
-// ============================================================================
-// Error Types
-// ============================================================================
-
-export interface ApiError {
-  status: number;
-  error: string;
-  detail?: string;
-}
-
-export function isApiError(value: unknown): value is ApiError {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'status' in value &&
-    typeof (value as any).status === 'number' &&
-    'error' in value &&
-    typeof (value as any).error === 'string'
-  );
-}
+// ApiError interface and isApiError guard always included (see Error Type section)
 ```
 
 ## Common Errors

--- a/skills/professional-communication/SKILL.md
+++ b/skills/professional-communication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: professional-communication
-description: Guide technical communication for software developers. Covers email structure, team messaging etiquette, meeting agendas, and adapting messages for technical vs non-technical audiences. Use when drafting professional messages, preparing meeting communications, or improving written communication.
+description: Guide technical communication for software developers. Covers email structure, Slack and Teams messaging etiquette, meeting agendas, PR descriptions, code review comments, and adapting messages for technical vs non-technical audiences. Use when developers need help writing emails, crafting Slack messages, phrasing PR descriptions, explaining code to non-technical stakeholders, preparing meeting agendas, writing status updates, or adjusting tone for different audiences.
 allowed-tools: Read, Glob, Grep
 ---
 
@@ -8,22 +8,23 @@ allowed-tools: Read, Glob, Grep
 
 ## Overview
 
-This skill provides frameworks and guidance for effective professional communication in software development contexts. Whether you're writing an email to stakeholders, crafting a team chat message, or preparing meeting agendas, these principles help you communicate clearly and build professional credibility.
+Frameworks and templates for professional communication in software development: emails, Slack/Teams messages, PR descriptions, meeting agendas, and cross-audience translation.
 
-**Core principle:** Effective communication isn't about proving how much you know - it's about ensuring your message is received and understood.
+**Core principle:** Ensure your message is received and understood by the right audience.
 
 ## When to Use This Skill
 
 Use this skill when:
 
 - Writing emails to teammates, managers, or stakeholders
-- Crafting team chat messages or async communications
+- Crafting Slack, Teams, or Discord messages and async communications
+- Writing PR descriptions or code review comments
 - Preparing meeting agendas or summaries
 - Translating technical concepts for non-technical audiences
-- Structuring status updates or reports
-- Improving clarity of written communication
+- Structuring status updates, reports, or incident postmortems
+- Adjusting tone or phrasing for different audiences
 
-**Keywords**: email, chat, teams, slack, discord, message, writing, communication, meeting, agenda, status update, report
+**Keywords**: email, write an email, chat, teams, slack, discord, message, writing, communication, meeting, agenda, status update, report, PR description, code review, how to phrase, tone, postmortem
 
 ## Core Frameworks
 
@@ -41,9 +42,9 @@ Use this universal framework to organize any professional message:
 
 ### Three Golden Rules for Written Communication
 
-1. **Start with a clear subject/purpose** - Recipients should immediately grasp what your message is about
-2. **Use bullets, headlines, and scannable formatting** - Nobody wants a wall of text
-3. **Key messages first** - Busy people appreciate efficiency; state your main point upfront
+1. **Start with a clear subject/purpose** - Recipients should immediately grasp intent
+2. **Use bullets, headlines, and scannable formatting** - Make content skimmable
+3. **Key messages first** - State your main point upfront
 
 ### Audience Calibration
 
@@ -158,8 +159,6 @@ You: Hi Sarah - quick question about the deployment script.
 
 | Technical | Plain Language |
 | --- | --- |
-| "Microservices architecture" | "Our system is split into smaller, independent pieces that can scale separately" |
-| "Asynchronous message processing" | "Tasks are queued and processed in the background" |
 | "CI/CD pipeline" | "Automated process that tests and deploys our code" |
 | "Database migration" | "Updating how our data is organized and stored" |
 
@@ -167,31 +166,9 @@ You: Hi Sarah - quick question about the deployment script.
 
 ## Writing Clarity Principles
 
-### Active Voice Over Passive Voice
-
-Active voice is clearer, more direct, and conveys authority:
-
-| Passive (avoid) | Active (prefer) |
-| --- | --- |
-| "A bug was identified by the team" | "The team identified a bug" |
-| "The feature will be implemented" | "We will implement the feature" |
-| "Errors were found during testing" | "Testing revealed errors" |
-
-### Eliminate Filler Words
-
-| Instead of | Use |
-| --- | --- |
-| "At this point in time" | "Now" |
-| "In the event that" | "If" |
-| "Due to the fact that" | "Because" |
-| "In order to" | "To" |
-| "I just wanted to check if" | "Can you" |
-
-### The "So What?" Test
-
-After writing, ask: "So what? Why does this matter to the reader?"
-
-If you can't answer clearly, restructure your message to lead with the value/impact.
+- **Prefer active voice** - "The team identified a bug" over "A bug was identified by the team"
+- **Cut filler phrases** - Replace "in order to" with "to", "due to the fact that" with "because", "I just wanted to check if" with "Can you"
+- **Apply the "So What?" test** - After writing, ask: "Why does this matter to the reader?" If unclear, restructure to lead with value/impact
 
 ## Meeting Communication
 

--- a/skills/qa-test-planner/SKILL.md
+++ b/skills/qa-test-planner/SKILL.md
@@ -1,176 +1,60 @@
 ---
 name: qa-test-planner
-description: Generate comprehensive test plans, manual test cases, regression test suites, and bug reports for QA engineers. Includes Figma MCP integration for design validation.
-trigger: explicit
+description: Generate test plans, manual test cases, regression suites, and bug reports. Use when the user asks for QA documentation, testing strategies, test scenarios, acceptance criteria, test coverage plans, or needs to validate UI implementations against Figma designs. Trigger phrases include "write test cases", "create a test plan", "build regression suite", "QA this feature", "quality assurance", and "compare with Figma design".
 ---
 
 # QA Test Planner
 
-A comprehensive skill for QA engineers to create test plans, generate manual test cases, build regression test suites, validate designs against Figma, and document bugs effectively.
+Generate structured QA deliverables: test plans, manual test cases, regression suites, Figma design validation checklists, and bug reports.
 
-> **Activation:** This skill is triggered only when explicitly called by name (e.g., `/qa-test-planner`, `qa-test-planner`, or `use the skill qa-test-planner`).
+## Workflow
 
----
+1. **Analyze** the feature or requirement:
+   - Identify what test types are needed (functional, UI, integration, regression)
+   - Determine scope boundaries (what is in/out of testing)
+   - Assess risk areas and priorities
+2. **Generate** structured deliverables using the templates below
+3. **Validate** output completeness:
+   - Every test step has an expected result
+   - Preconditions and test data are documented
+   - Priority is assigned to each test case
+   - If validation fails, revise before delivering
 
-## Quick Start
+## Scripts
 
-**Create a test plan:**
-```
-"Create a test plan for the user authentication feature"
-```
-
-**Generate test cases:**
-```
-"Generate manual test cases for the checkout flow"
-```
-
-**Build regression suite:**
-```
-"Build a regression test suite for the payment module"
-```
-
-**Validate against Figma:**
-```
-"Compare the login page against the Figma design at [URL]"
-```
-
-**Create bug report:**
-```
-"Create a bug report for the form validation issue"
-```
-
----
+| Script | Purpose | Example |
+|--------|---------|---------|
+| `./scripts/generate_test_cases.sh` | Create test cases interactively | Run, then follow prompts for feature name, scope, and priority |
+| `./scripts/create_bug_report.sh` | Generate structured bug reports | Run, then provide reproduction steps, environment, and severity |
 
 ## Quick Reference
 
-| Task | What You Get | Time |
-|------|--------------|------|
-| Test Plan | Strategy, scope, schedule, risks | 10-15 min |
-| Test Cases | Step-by-step instructions, expected results | 5-10 min each |
-| Regression Suite | Smoke tests, critical paths, execution order | 15-20 min |
-| Figma Validation | Design-implementation comparison, discrepancy list | 10-15 min |
-| Bug Report | Reproducible steps, environment, evidence | 5 min |
-
----
-
-## How It Works
-
-```
-Your Request
-    │
-    ▼
-┌─────────────────────────────────────────────────────┐
-│ 1. ANALYZE                                          │
-│    • Parse feature/requirement                      │
-│    • Identify test types needed                     │
-│    • Determine scope and priorities                 │
-├─────────────────────────────────────────────────────┤
-│ 2. GENERATE                                         │
-│    • Create structured deliverables                 │
-│    • Apply templates and best practices             │
-│    • Include edge cases and variations              │
-├─────────────────────────────────────────────────────┤
-│ 3. VALIDATE                                         │
-│    • Check completeness                             │
-│    • Verify traceability                            │
-│    • Ensure actionable steps                        │
-└─────────────────────────────────────────────────────┘
-    │
-    ▼
-QA Deliverable Ready
-```
-
----
-
-## Commands
-
-### Interactive Scripts
-
-| Script | Purpose | Usage |
-|--------|---------|-------|
-| `./scripts/generate_test_cases.sh` | Create test cases interactively | Step-by-step prompts |
-| `./scripts/create_bug_report.sh` | Generate bug reports | Guided input collection |
-
-### Natural Language
-
 | Request | Output |
 |---------|--------|
-| "Create test plan for {feature}" | Complete test plan document |
-| "Generate {N} test cases for {feature}" | Numbered test cases with steps |
-| "Build smoke test suite" | Critical path tests |
-| "Compare with Figma at {URL}" | Visual validation checklist |
-| "Document bug: {description}" | Structured bug report |
-
----
-
-## Core Deliverables
-
-### 1. Test Plans
-- Test scope and objectives
-- Testing approach and strategy
-- Environment requirements
-- Entry/exit criteria
-- Risk assessment
-- Timeline and milestones
-
-### 2. Manual Test Cases
-- Step-by-step instructions
-- Expected vs actual results
-- Preconditions and setup
-- Test data requirements
-- Priority and severity
-
-### 3. Regression Suites
-- Smoke tests (15-30 min)
-- Full regression (2-4 hours)
-- Targeted regression (30-60 min)
-- Execution order and dependencies
-
-### 4. Figma Validation
-- Component-by-component comparison
-- Spacing and typography checks
-- Color and visual consistency
-- Interactive state validation
-
-### 5. Bug Reports
-- Clear reproduction steps
-- Environment details
-- Evidence (screenshots, logs)
-- Severity and priority
-
----
+| "Create test plan for {feature}" | Complete test plan with scope, strategy, risks, entry/exit criteria |
+| "Generate {N} test cases for {feature}" | Numbered test cases with steps and expected results |
+| "Build smoke test suite" | P0 critical-path tests (15-30 min execution) |
+| "Compare with Figma at {URL}" | Component-by-component visual validation checklist |
+| "Document bug: {description}" | Structured bug report with reproduction steps |
 
 ## Anti-Patterns
 
-| Avoid | Why | Instead |
-|-------|-----|---------|
-| Vague test steps | Can't reproduce | Specific actions + expected results |
-| Missing preconditions | Tests fail unexpectedly | Document all setup requirements |
-| No test data | Tester blocked | Provide sample data or generation |
-| Generic bug titles | Hard to track | Specific: "[Feature] issue when [action]" |
-| Skip edge cases | Miss critical bugs | Include boundary values, nulls |
-
----
+| Avoid | Instead |
+|-------|---------|
+| Vague test steps | Specific actions + expected results |
+| Missing preconditions | Document all setup requirements |
+| No test data | Provide sample data or generation instructions |
+| Generic bug titles | Specific: "[Feature] issue when [action]" |
+| Skipping edge cases | Include boundary values, nulls, empty states |
 
 ## Verification Checklist
 
-**Test Plan:**
-- [ ] Scope clearly defined (in/out)
-- [ ] Entry/exit criteria specified
-- [ ] Risks identified with mitigations
-- [ ] Timeline realistic
+After generating any deliverable, verify:
 
-**Test Cases:**
-- [ ] Each step has expected result
-- [ ] Preconditions documented
-- [ ] Test data available
-- [ ] Priority assigned
-
-**Bug Reports:**
-- [ ] Reproducible steps
-- [ ] Environment documented
-- [ ] Screenshots/evidence attached
-- [ ] Severity/priority set
+- [ ] **Test plans**: Scope defined (in/out), entry/exit criteria specified, risks identified with mitigations
+- [ ] **Test cases**: Each step has expected result, preconditions documented, test data available, priority assigned
+- [ ] **Bug reports**: Reproducible steps, environment documented, evidence attached, severity/priority set
+- [ ] **Figma validation**: Design specs extracted, implementation compared per-component, discrepancies logged as bugs
 
 ---
 
@@ -184,9 +68,7 @@ QA Deliverable Ready
 ---
 
 <details>
-<summary><strong>Deep Dive: Test Case Structure</strong></summary>
-
-### Standard Test Case Format
+<summary><strong>Template: Test Case</strong></summary>
 
 ```markdown
 ## TC-001: [Test Case Title]
@@ -195,158 +77,82 @@ QA Deliverable Ready
 **Type:** Functional | UI | Integration | Regression
 **Status:** Not Run | Pass | Fail | Blocked
 
-### Objective
-[What are we testing and why]
-
 ### Preconditions
 - [Setup requirement 1]
-- [Setup requirement 2]
 - [Test data needed]
 
 ### Test Steps
 1. [Action to perform]
    **Expected:** [What should happen]
-
 2. [Action to perform]
-   **Expected:** [What should happen]
-
-3. [Action to perform]
    **Expected:** [What should happen]
 
 ### Test Data
 - Input: [Test data values]
 - User: [Test account details]
-- Configuration: [Environment settings]
 
 ### Post-conditions
 - [System state after test]
 - [Cleanup required]
-
-### Notes
-- [Edge cases to consider]
-- [Related test cases]
-- [Known issues]
 ```
-
-### Test Types
-
-| Type | Focus | Example |
-|------|-------|---------|
-| Functional | Business logic | Login with valid credentials |
-| UI/Visual | Appearance, layout | Button matches Figma design |
-| Integration | Component interaction | API returns data to frontend |
-| Regression | Existing functionality | Previous features still work |
-| Performance | Speed, load handling | Page loads under 3 seconds |
-| Security | Vulnerabilities | SQL injection prevented |
 
 </details>
 
 <details>
-<summary><strong>Deep Dive: Test Plan Template</strong></summary>
-
-### Test Plan Structure
+<summary><strong>Template: Test Plan</strong></summary>
 
 ```markdown
 # Test Plan: [Feature/Release Name]
 
 ## Executive Summary
-- Feature/product being tested
-- Testing objectives
-- Key risks
-- Timeline overview
+- Feature being tested, objectives, key risks, timeline
 
 ## Test Scope
-
-**In Scope:**
-- Features to be tested
-- Test types (functional, UI, performance)
-- Platforms and environments
-- User flows and scenarios
-
-**Out of Scope:**
-- Features not being tested
-- Known limitations
-- Third-party integrations (if applicable)
+**In Scope:** Features, test types, platforms, user flows
+**Out of Scope:** Features excluded, known limitations
 
 ## Test Strategy
-
-**Test Types:**
-- Manual testing
-- Exploratory testing
-- Regression testing
-- Integration testing
-- User acceptance testing
-
-**Test Approach:**
-- Black box testing
-- Positive and negative testing
-- Boundary value analysis
-- Equivalence partitioning
+- Test types: Manual, exploratory, regression, integration, UAT
+- Approach: Black box, positive/negative, boundary value analysis
 
 ## Test Environment
-- Operating systems
-- Browsers and versions
-- Devices (mobile, tablet, desktop)
-- Test data requirements
-- Backend/API environments
+- OS, browsers, devices, test data, backend environments
 
 ## Entry Criteria
 - [ ] Requirements documented
-- [ ] Designs finalized
 - [ ] Test environment ready
-- [ ] Test data prepared
 - [ ] Build deployed
 
 ## Exit Criteria
 - [ ] All high-priority test cases executed
-- [ ] 90%+ test case pass rate
-- [ ] All critical bugs fixed
-- [ ] No open high-severity bugs
-- [ ] Regression suite passed
+- [ ] 90%+ pass rate
+- [ ] No open critical bugs
 
 ## Risk Assessment
-
 | Risk | Probability | Impact | Mitigation |
 |------|-------------|--------|------------|
 | [Risk 1] | H/M/L | H/M/L | [Mitigation] |
-
-## Test Deliverables
-- Test plan document
-- Test cases
-- Test execution reports
-- Bug reports
-- Test summary report
 ```
 
 </details>
 
 <details>
-<summary><strong>Deep Dive: Bug Reporting</strong></summary>
-
-### Bug Report Template
+<summary><strong>Template: Bug Report</strong></summary>
 
 ```markdown
 # BUG-[ID]: [Clear, specific title]
 
 **Severity:** Critical | High | Medium | Low
 **Priority:** P0 | P1 | P2 | P3
-**Type:** Functional | UI | Performance | Security
-**Status:** Open | In Progress | Fixed | Closed
 
 ## Environment
 - **OS:** [Windows 11, macOS 14, etc.]
 - **Browser:** [Chrome 120, Firefox 121, etc.]
-- **Device:** [Desktop, iPhone 15, etc.]
 - **Build:** [Version/commit]
-- **URL:** [Page where bug occurs]
-
-## Description
-[Clear, concise description of the issue]
 
 ## Steps to Reproduce
 1. [Specific step]
 2. [Specific step]
-3. [Specific step]
 
 ## Expected Behavior
 [What should happen]
@@ -354,306 +160,63 @@ QA Deliverable Ready
 ## Actual Behavior
 [What actually happens]
 
-## Visual Evidence
-- Screenshot: [attached]
-- Video: [link if applicable]
-- Console errors: [paste errors]
-
 ## Impact
-- **User Impact:** [How many users affected]
 - **Frequency:** [Always, Sometimes, Rarely]
 - **Workaround:** [If one exists]
-
-## Additional Context
-- Related to: [Feature/ticket]
-- Regression: [Yes/No]
-- Figma design: [Link if UI bug]
+- **Figma design:** [Link if UI bug]
 ```
-
-### Severity Definitions
-
-| Level | Criteria | Examples |
-|-------|----------|----------|
-| **Critical (P0)** | System crash, data loss, security | Payment fails, login broken |
-| **High (P1)** | Major feature broken, no workaround | Search not working |
-| **Medium (P2)** | Feature partial, workaround exists | Filter missing one option |
-| **Low (P3)** | Cosmetic, rare edge cases | Typo, minor alignment |
 
 </details>
 
 <details>
-<summary><strong>Deep Dive: Figma MCP Integration</strong></summary>
+<summary><strong>Figma MCP Validation Process</strong></summary>
 
-### Design Validation Workflow
+**Prerequisites:** Figma MCP server configured, access to design files.
 
-**Prerequisites:**
-- Figma MCP server configured
-- Access to Figma design files
-- Figma URLs for components/pages
-
-**Process:**
-
-1. **Get Design Specs from Figma**
+**Step 1 — Extract design specs:**
 ```
 "Get the button specifications from Figma file [URL]"
-
-Response includes:
-- Dimensions (width, height)
-- Colors (background, text, border)
-- Typography (font, size, weight)
-- Spacing (padding, margin)
-- Border radius
-- States (default, hover, active, disabled)
+→ Returns: dimensions, colors, typography, spacing, border radius, states
 ```
 
-2. **Compare Implementation**
+**Step 2 — Compare implementation against specs:**
 ```
 TC: Primary Button Visual Validation
 1. Inspect primary button in browser dev tools
-2. Compare against Figma specs:
-   - Dimensions: 120x40px
-   - Border-radius: 8px
-   - Background color: #0066FF
-   - Font: 16px Medium #FFFFFF
+2. Compare: dimensions (120x40px), border-radius (8px), background (#0066FF), font (16px Medium #FFFFFF)
 3. Document discrepancies
 ```
 
-3. **Create Bug if Mismatch**
+**Step 3 — File bug if mismatch:**
 ```
 BUG: Primary button color doesn't match design
-Severity: Medium
-Expected (Figma): #0066FF
-Actual (Implementation): #0052CC
-Screenshot: [attached]
-Figma link: [specific component]
+Expected (Figma): #0066FF | Actual: #0052CC
 ```
 
-### What to Validate
-
-| Element | What to Check | Tool |
-|---------|---------------|------|
-| Colors | Hex values exact | Browser color picker |
-| Spacing | Padding/margin px | DevTools computed styles |
-| Typography | Font, size, weight | DevTools font panel |
-| Layout | Width, height, position | DevTools box model |
-| States | Hover, active, focus | Manual interaction |
-| Responsive | Breakpoint behavior | DevTools device mode |
-
-### Example Queries
-```
-"Get button specifications from Figma design [URL]"
-"Compare navigation menu implementation against Figma design"
-"Extract spacing values for dashboard layout from Figma"
-"List all color tokens used in Figma design system"
-```
+**What to validate per component:** Colors (exact hex), spacing (padding/margin px), typography (font/size/weight), layout (width/height), interactive states (hover/active/focus), responsive breakpoints.
 
 </details>
 
 <details>
-<summary><strong>Deep Dive: Regression Testing</strong></summary>
+<summary><strong>Regression Suite Building</strong></summary>
 
-### Suite Structure
+| Suite Type | Duration | When to Run |
+|------------|----------|-------------|
+| Smoke | 15-30 min | Daily / every deploy |
+| Targeted | 30-60 min | Per feature change |
+| Full | 2-4 hours | Weekly / pre-release |
 
-| Suite Type | Duration | Frequency | Coverage |
-|------------|----------|-----------|----------|
-| Smoke | 15-30 min | Daily | Critical paths only |
-| Targeted | 30-60 min | Per change | Affected areas |
-| Full | 2-4 hours | Weekly/Release | Comprehensive |
-| Sanity | 10-15 min | After hotfix | Quick validation |
+**Build process:**
+1. Identify critical paths (revenue, security, high-usage features)
+2. Assign priorities: P0 (always run), P1 (weekly+), P2 (releases only)
+3. Execute in order: Smoke → P0 → P1 → P2 → Exploratory
+4. If any P0 fails → stop execution, fix build, restart
 
-### Building a Regression Suite
-
-**Step 1: Identify Critical Paths**
-- What can users NOT live without?
-- What generates revenue?
-- What handles sensitive data?
-- What's used most frequently?
-
-**Step 2: Prioritize Test Cases**
-
-| Priority | Description | Must Run |
-|----------|-------------|----------|
-| P0 | Business-critical, security | Always |
-| P1 | Major features, common flows | Weekly+ |
-| P2 | Minor features, edge cases | Releases |
-
-**Step 3: Execution Order**
-1. Smoke first - if fails, stop and fix build
-2. P0 tests next - must pass before proceeding
-3. P1 then P2 - track all failures
-4. Exploratory - find unexpected issues
-
-### Pass/Fail Criteria
-
-**PASS:**
-- All P0 tests pass
-- 90%+ P1 tests pass
-- No critical bugs open
-
-**FAIL (Block Release):**
-- Any P0 test fails
-- Critical bug discovered
-- Security vulnerability
-- Data loss scenario
-
-**CONDITIONAL:**
-- P1 failures with workarounds
-- Known issues documented
-- Fix plan in place
-
-</details>
-
-<details>
-<summary><strong>Deep Dive: Test Execution Tracking</strong></summary>
-
-### Test Run Report Template
-
-```markdown
-# Test Run: [Release Version]
-
-**Date:** 2024-01-15
-**Build:** v2.5.0-rc1
-**Tester:** [Name]
-**Environment:** Staging
-
-## Summary
-- Total Test Cases: 150
-- Executed: 145
-- Passed: 130
-- Failed: 10
-- Blocked: 5
-- Not Run: 5
-- Pass Rate: 90%
-
-## Test Cases by Priority
-
-| Priority | Total | Pass | Fail | Blocked |
-|----------|-------|------|------|---------|
-| P0 (Critical) | 25 | 23 | 2 | 0 |
-| P1 (High) | 50 | 45 | 3 | 2 |
-| P2 (Medium) | 50 | 45 | 3 | 2 |
-| P3 (Low) | 25 | 17 | 2 | 1 |
-
-## Critical Failures
-- TC-045: Payment processing fails
-  - Bug: BUG-234
-  - Status: Open
-
-## Blocked Tests
-- TC-112: Dashboard widget (API endpoint down)
-
-## Risks
-- 2 critical bugs blocking release
-- Payment integration needs attention
-
-## Next Steps
-- Retest after BUG-234 fix
-- Complete remaining 5 test cases
-- Run full regression before sign-off
-```
-
-### Coverage Tracking
-
-```markdown
-## Coverage Matrix
-
-| Feature | Requirements | Test Cases | Status | Gaps |
-|---------|--------------|------------|--------|------|
-| Login | 8 | 12 | Complete | None |
-| Checkout | 15 | 10 | Partial | Payment errors |
-| Dashboard | 12 | 15 | Complete | None |
-```
-
-</details>
-
-<details>
-<summary><strong>QA Process Workflow</strong></summary>
-
-### Phase 1: Planning
-- [ ] Review requirements and designs
-- [ ] Create test plan
-- [ ] Identify test scenarios
-- [ ] Estimate effort and timeline
-- [ ] Set up test environment
-
-### Phase 2: Test Design
-- [ ] Write test cases
-- [ ] Review test cases with team
-- [ ] Prepare test data
-- [ ] Build regression suite
-- [ ] Get Figma design access
-
-### Phase 3: Execution
-- [ ] Execute test cases
-- [ ] Log bugs with clear steps
-- [ ] Validate against Figma (UI tests)
-- [ ] Track test progress
-- [ ] Communicate blockers
-
-### Phase 4: Reporting
-- [ ] Compile test results
-- [ ] Analyze coverage
-- [ ] Document risks
-- [ ] Provide go/no-go recommendation
-- [ ] Archive test artifacts
-
-</details>
-
-<details>
-<summary><strong>Best Practices</strong></summary>
-
-### Test Case Writing
-
-**DO:**
-- Be specific and unambiguous
-- Include expected results for each step
-- Test one thing per test case
-- Use consistent naming conventions
-- Keep test cases maintainable
-
-**DON'T:**
-- Assume knowledge
-- Make test cases too long
-- Skip preconditions
-- Forget edge cases
-- Leave expected results vague
-
-### Bug Reporting
-
-**DO:**
-- Provide clear reproduction steps
-- Include screenshots/videos
-- Specify exact environment details
-- Describe impact on users
-- Link to Figma for UI bugs
-
-**DON'T:**
-- Report without reproduction steps
-- Use vague descriptions
-- Skip environment details
-- Forget to assign priority
-- Duplicate existing bugs
-
-### Regression Testing
-
-**DO:**
-- Automate repetitive tests when possible
-- Maintain regression suite regularly
-- Prioritize critical paths
-- Run smoke tests frequently
-- Update suite after each release
-
-**DON'T:**
-- Skip regression before releases
-- Let suite become outdated
-- Test everything every time
-- Ignore failed regression tests
+**Release gate:** All P0 pass, 90%+ P1 pass, no critical bugs open. If P1 failures have workarounds and fix plan exists → conditional pass.
 
 </details>
 
 ---
-
-## Examples
 
 <details>
 <summary><strong>Example: Login Flow Test Case</strong></summary>
@@ -661,97 +224,54 @@ Figma link: [specific component]
 ```markdown
 ## TC-LOGIN-001: Valid User Login
 
-**Priority:** P0 (Critical)
-**Type:** Functional
-**Estimated Time:** 2 minutes
-
-### Objective
-Verify users can successfully login with valid credentials
+**Priority:** P0 (Critical)  |  **Type:** Functional
 
 ### Preconditions
 - User account exists (test@example.com / Test123!)
-- User is not already logged in
-- Browser cookies cleared
+- User is not logged in, browser cookies cleared
 
 ### Test Steps
 1. Navigate to https://app.example.com/login
    **Expected:** Login page displays with email and password fields
-
 2. Enter email: test@example.com
    **Expected:** Email field accepts input
-
 3. Enter password: Test123!
    **Expected:** Password field shows masked characters
-
 4. Click "Login" button
-   **Expected:**
-   - Loading indicator appears
-   - User redirected to /dashboard
-   - Welcome message shown: "Welcome back, Test User"
-   - Avatar/profile image displayed in header
+   **Expected:** Loading indicator → redirect to /dashboard → "Welcome back, Test User" shown
 
 ### Post-conditions
-- User session created
-- Auth token stored
-- Analytics event logged
+- User session created, auth token stored
 
-### Edge Cases to Consider
-- TC-LOGIN-002: Invalid password
-- TC-LOGIN-003: Non-existent email
-- TC-LOGIN-004: SQL injection attempt
-- TC-LOGIN-005: Very long password
+### Related Edge Cases
+- TC-LOGIN-002: Invalid password → error message shown
+- TC-LOGIN-003: Non-existent email → "account not found"
+- TC-LOGIN-004: SQL injection attempt → input sanitized
 ```
 
 </details>
 
 <details>
-<summary><strong>Example: Responsive Design Test Case</strong></summary>
+<summary><strong>Example: Figma Responsive Validation</strong></summary>
 
 ```markdown
 ## TC-UI-045: Mobile Navigation Menu
 
-**Priority:** P1 (High)
-**Type:** UI/Responsive
-**Devices:** Mobile (iPhone, Android)
-
-### Objective
-Verify navigation menu works correctly on mobile devices
+**Priority:** P1 (High)  |  **Type:** UI/Responsive
 
 ### Preconditions
-- Access from mobile device or responsive mode
-- Viewport width: 375px (iPhone SE) to 428px (iPhone Pro Max)
+- Viewport width: 375px–428px (mobile range)
 
 ### Test Steps
 1. Open homepage on mobile device
    **Expected:** Hamburger menu icon visible (top-right)
-
 2. Tap hamburger icon
-   **Expected:**
-   - Menu slides in from right
-   - Overlay appears over content
-   - Close (X) button visible
-
-3. Tap menu item
-   **Expected:** Navigate to section, menu closes
-
-4. Compare against Figma mobile design [link]
-   **Expected:**
-   - Menu width: 280px
-   - Slide animation: 300ms ease-out
-   - Overlay opacity: 0.5, color #000000
-   - Font size: 16px, line-height 24px
+   **Expected:** Menu slides in from right, overlay appears, close (X) button visible
+3. Compare against Figma mobile design [link]
+   **Expected:** Menu width 280px, slide animation 300ms ease-out, overlay opacity 0.5 #000000, font 16px/24px
 
 ### Breakpoints to Test
-- 375px (iPhone SE)
-- 390px (iPhone 14)
-- 428px (iPhone 14 Pro Max)
-- 360px (Galaxy S21)
+375px (iPhone SE), 390px (iPhone 14), 428px (iPhone Pro Max), 360px (Galaxy S21)
 ```
 
 </details>
-
----
-
-**"Testing shows the presence, not the absence of bugs." - Edsger Dijkstra**
-
-**"Quality is not an act, it is a habit." - Aristotle**

--- a/skills/react-useeffect/SKILL.md
+++ b/skills/react-useeffect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-useeffect
-description: React useEffect best practices from official docs. Use when writing/reviewing useEffect, useState for derived values, data fetching, or state synchronization. Teaches when NOT to use Effect and better alternatives.
+description: React useEffect best practices and anti-patterns from official docs. Use when writing, reviewing, or refactoring useEffect hooks, replacing useState-derived values with direct calculations, optimizing re-renders with useMemo, or resetting component state with key props. Teaches when NOT to use an Effect and provides concrete code alternatives.
 ---
 
 # You Might Not Need an Effect
@@ -45,6 +45,46 @@ Need to respond to something?
 │       └── Expensive? Use useMemo
 └── Need to reset state when prop changes?
     └── Use KEY PROP on component
+```
+
+## Common Patterns: Before/After
+
+### Derived State (Most Common Anti-Pattern)
+
+```jsx
+// BAD: useState + useEffect for derived value
+const [fullName, setFullName] = useState('');
+useEffect(() => {
+  setFullName(firstName + ' ' + lastName);
+}, [firstName, lastName]);
+
+// GOOD: Calculate during render
+const fullName = firstName + ' ' + lastName;
+```
+
+### Expensive Calculation
+
+```jsx
+// BAD: useEffect to cache
+const [filtered, setFiltered] = useState([]);
+useEffect(() => {
+  setFiltered(items.filter(i => i.active));
+}, [items]);
+
+// GOOD: useMemo
+const filtered = useMemo(() => items.filter(i => i.active), [items]);
+```
+
+### Reset State on Prop Change
+
+```jsx
+// BAD: useEffect to reset
+useEffect(() => {
+  setComment('');
+}, [userId]);
+
+// GOOD: Key prop forces remount
+<CommentForm key={userId} />
 ```
 
 ## Detailed Guidance

--- a/skills/reducing-entropy/SKILL.md
+++ b/skills/reducing-entropy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reducing-entropy
-description: Manual-only skill for minimizing total codebase size. Only activate when explicitly requested by user. Measures success by final code amount, not effort. Bias toward deletion.
+description: "Use when the user asks to reduce code, clean up codebase, remove dead code, shrink footprint, or minimize code size. Manual-only — only activate when explicitly requested. Removes dead code, consolidates duplicate functions, eliminates unused dependencies, and simplifies over-engineered abstractions. Measures success by final line count, not effort. Bias toward deletion."
 ---
 
 # Reducing Entropy
@@ -63,6 +63,34 @@ Every change is an opportunity to delete. Ask:
 - **"Better separation of concerns"** - More files/functions = more code. Separation isn't free.
 - **"Type safety"** - Worth how many lines? Sometimes runtime checks in less code wins.
 - **"Easier to understand"** - 14 things are not easier than 2 things.
+
+## Reduction Workflow
+
+1. **Measure** — count lines before starting:
+   ```bash
+   find . -name '*.ts' -o -name '*.js' | xargs wc -l | tail -1
+   ```
+2. **Identify** dead code targets:
+   - Unused exports (no importers)
+   - Unreachable branches or feature-flagged dead paths
+   - Orphaned files with no references
+   - Duplicate functions doing the same thing with slight variations
+3. **Delete or consolidate** — apply changes
+4. **Verify** — run tests to confirm nothing breaks:
+   ```bash
+   npm test  # or the project's equivalent
+   ```
+5. **Measure again** — confirm the line count dropped. If it didn't, reconsider.
+
+## Concrete Example
+
+A module has 14 helper functions across 3 files (280 lines) for API response formatting:
+
+- **Before:** `formatUser()`, `formatPost()`, `formatComment()`, ... 14 functions, 280 lines
+- **After:** 1 generic `formatEntity(schema)` + a schema map, 45 lines
+- **Net result:** -235 lines. The 45 lines of new code deleted 280 lines of old code.
+
+The question is not "is 45 lines a lot to write?" — it is "is the codebase smaller after?"
 
 ## When This Doesn't Apply
 

--- a/skills/requirements-clarity/SKILL.md
+++ b/skills/requirements-clarity/SKILL.md
@@ -1,324 +1,69 @@
 ---
 name: requirements-clarity
-description: Clarify ambiguous requirements through focused dialogue before implementation. Use when requirements are unclear, features are complex (>2 days), or involve cross-team coordination. Ask two core questions - Why? (YAGNI check) and Simpler? (KISS check) - to ensure clarity before coding.
+description: Transform vague requirements into actionable PRDs through structured clarification dialogue. Use when someone says "build me a feature", "I need a dashboard", "scope this project", "spec out", "what should I build", or before starting any complex feature (>2 days effort, cross-team, or unclear acceptance criteria). Scores clarity 0-100 and iterates until requirements are implementation-ready.
 ---
 
 # Requirements Clarity Skill
 
-## Description
-
-Automatically transforms vague requirements into actionable PRDs through systematic clarification with a 100-point scoring system.
+Transform vague feature requests into concrete, implementation-ready PRDs through iterative clarification dialogue scored on a 100-point rubric.
 
+## When to Activate
 
-## Instructions
+Activate when requirements lack specific acceptance criteria, technical constraints, or clear scope boundaries — e.g., "add login feature", "implement payment", "create dashboard", or any request missing the "how" and "what exactly."
 
-When invoked, detect vague requirements:
+Do NOT activate when the user provides specific file paths, code snippets, existing function references, or bug fixes with clear reproduction steps.
 
-1. **Vague Feature Requests**
-   - User says: "add login feature", "implement payment", "create dashboard"
-   - Missing: How, with what technology, what constraints?
+## Workflow
 
-2. **Missing Technical Context**
-   - No technology stack mentioned
-   - No integration points identified
-   - No performance/security constraints
+### Step 1: Assess Initial Clarity (Score 0-100)
 
-3. **Incomplete Specifications**
-   - No acceptance criteria
-   - No success metrics
-   - No edge cases considered
-   - No error handling mentioned
+Parse the requirement, generate a kebab-case feature name, and score against this rubric:
 
-4. **Ambiguous Scope**
-   - Unclear boundaries ("user management" - what exactly?)
-   - No distinction between MVP and future enhancements
-   - Missing "what's NOT included"
+| Category | Points | Criteria |
+|----------|--------|----------|
+| Functional Clarity | /30 | Clear inputs/outputs (10), user interaction defined (10), success criteria stated (10) |
+| Technical Specificity | /25 | Tech stack mentioned (8), integration points identified (8), constraints specified (9) |
+| Implementation Completeness | /25 | Edge cases considered (8), error handling mentioned (9), data validation specified (8) |
+| Business Context | /20 | Problem statement clear (7), target users identified (7), success metrics defined (6) |
 
-**Do NOT activate when**:
-- Specific file paths mentioned (e.g., "auth.go:45")
-- Code snippets included
-- Existing functions/classes referenced
-- Bug fixes with clear reproduction steps
-
-## Core Principles
+Respond with the current score, what is clear, and what needs clarification.
 
-1. **Systematic Questioning**
-   - Ask focused, specific questions
-   - One category at a time (2-3 questions per round)
-   - Build on previous answers
-   - Avoid overwhelming users
-
-2. **Quality-Driven Iteration**
-   - Continuously assess clarity score (0-100)
-   - Identify gaps systematically
-   - Iterate until ≥ 90 points
-   - Document all clarification rounds
-
-3. **Actionable Output**
-   - Generate concrete specifications
-   - Include measurable acceptance criteria
-   - Provide executable phases
-   - Enable direct implementation
+### Step 2: Iterative Clarification
 
-## Clarification Process
+Ask 2-3 focused questions per round, prioritizing highest-impact gaps across four dimensions:
 
-### Step 1: Initial Requirement Analysis
+1. **Functional Scope** — core functionality, boundaries, out-of-scope, edge cases
+2. **User Interaction** — inputs, outputs, success/failure scenarios
+3. **Technical Constraints** — performance, compatibility, security, scalability
+4. **Business Value** — problem solved, target users, success metrics, priority
 
-**Input**: User's requirement description
+After each response, update the score and summarize new information. Continue until score reaches 90+.
 
-**Tasks**:
-1. Parse and understand core requirement
-2. Generate feature name (kebab-case format)
-3. Determine document version (default `1.0` unless user specifies otherwise)
-4. Ensure `./docs/prds/` exists for PRD output
-5. Perform initial clarity assessment (0-100)
-
-**Assessment Rubric**:
-```
-Functional Clarity: /30 points
-- Clear inputs/outputs: 10 pts
-- User interaction defined: 10 pts
-- Success criteria stated: 10 pts
+**Example Clarification Round:**
 
-Technical Specificity: /25 points
-- Technology stack mentioned: 8 pts
-- Integration points identified: 8 pts
-- Constraints specified: 9 pts
+> User: "I need a payment integration"
+>
+> **Clarity Score: 15/100**
+>
+> I need to clarify a few things:
+> 1. **Functional Scope**: Which payment provider(s) — Stripe, PayPal, or something else? One-time payments, subscriptions, or both?
+> 2. **Technical Constraints**: What's your current stack? Any PCI compliance requirements already in place?
+> 3. **Business Value**: What's the primary use case — e-commerce checkout, SaaS billing, or marketplace payouts?
 
-Implementation Completeness: /25 points
-- Edge cases considered: 8 pts
-- Error handling mentioned: 9 pts
-- Data validation specified: 8 pts
+### Step 3: Generate PRD
 
-Business Context: /20 points
-- Problem statement clear: 7 pts
-- Target users identified: 7 pts
-- Success metrics defined: 6 pts
-```
+Once score reaches 90+, write the PRD to `./docs/prds/{feature_name}-v{version}-prd.md` using the `Write` tool. The PRD must include:
 
-**Initial Response Format**:
-```markdown
-I understand your requirement. Let me help you refine this specification.
+- **Requirements Description**: background/problem, feature overview with boundaries, detailed requirements with inputs/outputs, edge cases, and data validation
+- **Design Decisions**: technical approach and rationale, key components, constraints (performance, security, scalability), risk assessment
+- **Acceptance Criteria**: checklistable items (`- [ ]` format) covering functional, quality, and user acceptance
+- **Execution Phases**: concrete tasks organized into preparation, core development, integration/testing, and deployment phases with time estimates
 
-**Current Clarity Score**: X/100
-
-**Clear Aspects**:
-- [List what's clear]
-
-**Needs Clarification**:
-- [List gaps]
-
-Let me systematically clarify these points...
-```
-
-### Step 2: Gap Analysis
-
-Identify missing information across four dimensions:
-
-**1. Functional Scope**
-- What is the core functionality?
-- What are the boundaries?
-- What is out of scope?
-- What are edge cases?
-
-**2. User Interaction**
-- How do users interact?
-- What are the inputs?
-- What are the outputs?
-- What are success/failure scenarios?
-
-**3. Technical Constraints**
-- Performance requirements?
-- Compatibility requirements?
-- Security considerations?
-- Scalability needs?
-
-**4. Business Value**
-- What problem does this solve?
-- Who are the target users?
-- What are success metrics?
-- What is the priority?
-
-### Step 3: Interactive Clarification
-
-**Question Strategy**:
-1. Start with highest-impact gaps
-2. Ask 2-3 questions per round
-3. Build context progressively
-4. Use user's language
-5. Provide examples when helpful
-
-**Question Format**:
-```markdown
-I need to clarify the following points to complete the requirements document:
-
-1. **[Category]**: [Specific question]?
-   - For example: [Example if helpful]
-
-2. **[Category]**: [Specific question]?
-
-3. **[Category]**: [Specific question]?
-
-Please provide your answers, and I'll continue refining the PRD.
-```
-
-**After Each User Response**:
-1. Update clarity score
-2. Capture new information in the working PRD outline
-3. Identify remaining gaps
-4. If score < 90: Continue with next round of questions
-5. If score ≥ 90: Proceed to PRD generation
-
-**Score Update Format**:
-```markdown
-Thank you for the additional information!
-
-**Clarity Score Update**: X/100 → Y/100
-
-**New Clarified Content**:
-- [Summarize new information]
-
-**Remaining Points to Clarify**:
-- [List remaining gaps if score < 90]
-
-[If score < 90: Continue with next round of questions]
-[If score ≥ 90: "Perfect! I will now generate the complete PRD document..."]
-```
-
-### Step 4: PRD Generation
-
-Once clarity score ≥ 90, generate comprehensive PRD.
-
-**Output File**:
-
-1. **Final PRD**: `./docs/prds/{feature_name}-v{version}-prd.md`
-
-Use the `Write` tool to create or update this file. Derive `{version}` from the document version recorded in the PRD (default `1.0`).
-
-## PRD Document Structure
-
-```markdown
-# {Feature Name} - Product Requirements Document (PRD)
-
-## Requirements Description
-
-### Background
-- **Business Problem**: [Describe the business problem to solve]
-- **Target Users**: [Target user groups]
-- **Value Proposition**: [Value this feature brings]
-
-### Feature Overview
-- **Core Features**: [List of main features]
-- **Feature Boundaries**: [What is and isn't included]
-- **User Scenarios**: [Typical usage scenarios]
-
-### Detailed Requirements
-- **Input/Output**: [Specific input/output specifications]
-- **User Interaction**: [User operation flow]
-- **Data Requirements**: [Data structures and validation rules]
-- **Edge Cases**: [Edge case handling]
-
-## Design Decisions
-
-### Technical Approach
-- **Architecture Choice**: [Technical architecture decisions and rationale]
-- **Key Components**: [List of main technical components]
-- **Data Storage**: [Data models and storage solutions]
-- **Interface Design**: [API/interface specifications]
-
-### Constraints
-- **Performance Requirements**: [Response time, throughput, etc.]
-- **Compatibility**: [System compatibility requirements]
-- **Security**: [Security considerations]
-- **Scalability**: [Future expansion considerations]
-
-### Risk Assessment
-- **Technical Risks**: [Potential technical risks and mitigation plans]
-- **Dependency Risks**: [External dependencies and alternatives]
-- **Schedule Risks**: [Timeline risks and response strategies]
-
-## Acceptance Criteria
-
-### Functional Acceptance
-- [ ] Feature 1: [Specific acceptance conditions]
-- [ ] Feature 2: [Specific acceptance conditions]
-- [ ] Feature 3: [Specific acceptance conditions]
-
-### Quality Standards
-- [ ] Code Quality: [Code standards and review requirements]
-- [ ] Test Coverage: [Testing requirements and coverage]
-- [ ] Performance Metrics: [Performance test pass criteria]
-- [ ] Security Review: [Security review requirements]
-
-### User Acceptance
-- [ ] User Experience: [UX acceptance criteria]
-- [ ] Documentation: [Documentation delivery requirements]
-- [ ] Training Materials: [If needed, training material requirements]
-
-## Execution Phases
-
-### Phase 1: Preparation
-**Goal**: Environment preparation and technical validation
-- [ ] Task 1: [Specific task description]
-- [ ] Task 2: [Specific task description]
-- **Deliverables**: [Phase deliverables]
-- **Time**: [Estimated time]
-
-### Phase 2: Core Development
-**Goal**: Implement core functionality
-- [ ] Task 1: [Specific task description]
-- [ ] Task 2: [Specific task description]
-- **Deliverables**: [Phase deliverables]
-- **Time**: [Estimated time]
-
-### Phase 3: Integration & Testing
-**Goal**: Integration and quality assurance
-- [ ] Task 1: [Specific task description]
-- [ ] Task 2: [Specific task description]
-- **Deliverables**: [Phase deliverables]
-- **Time**: [Estimated time]
-
-### Phase 4: Deployment
-**Goal**: Release and monitoring
-- [ ] Task 1: [Specific task description]
-- [ ] Task 2: [Specific task description]
-- **Deliverables**: [Phase deliverables]
-- **Time**: [Estimated time]
-
----
-
-**Document Version**: 1.0
-**Created**: {timestamp}
-**Clarification Rounds**: {clarification_rounds}
-**Quality Score**: {quality_score}/100
-```
-
-## Behavioral Guidelines
-
-### DO
-- Ask specific, targeted questions
-- Build on previous answers
-- Provide examples to guide users
-- Maintain conversational tone
-- Summarize clarification rounds within the PRD
-- Use clear, professional English
-- Generate concrete specifications
-- Stay in clarification mode until score ≥ 90
-
-### DON'T
-- Ask all questions at once
-- Make assumptions without confirmation
-- Generate PRD before 90+ score
-- Skip any required sections
-- Use vague or abstract language
-- Proceed without user responses
-- Exit skill mode prematurely
+Close the PRD with document version (default `1.0`), creation timestamp, number of clarification rounds, and final quality score.
 
 ## Success Criteria
 
-- Clarity score ≥ 90/100
-- All PRD sections complete with substance
-- Acceptance criteria checklistable (using `- [ ]` format)
-- Execution phases actionable with concrete tasks
-- User approves final PRD
-- Ready for development handoff
+- Clarity score reaches 90+/100 before PRD generation
+- All PRD sections contain substantive, specific content (no placeholders)
+- Acceptance criteria are checklistable and measurable
+- Execution phases have concrete tasks ready for development handoff

--- a/skills/ship-learn-next/SKILL.md
+++ b/skills/ship-learn-next/SKILL.md
@@ -1,328 +1,117 @@
 ---
 name: ship-learn-next
-description: Transform learning content (like YouTube transcripts, articles, tutorials) into actionable implementation plans using the Ship-Learn-Next framework. Use when user wants to turn advice, lessons, or educational content into concrete action steps, reps, or a learning quest.
-allowed-tools:
-  - Read
-  - Write
+description: >
+  Convert learning content into shippable action plans using the Ship-Learn-Next framework.
+  Use when the user says "turn this into a plan", "make this actionable", "I watched/read X, now what?",
+  or wants to extract implementation steps from a transcript, article, tutorial, or course notes.
+allowed-tools: Read, Write
 ---
 
 # Ship-Learn-Next Action Planner
 
-This skill helps transform passive learning content into actionable **Ship-Learn-Next cycles** - turning advice and lessons into concrete, shippable iterations.
+Transform passive learning content into actionable **Ship-Learn-Next cycles** — turning advice and lessons into concrete, shippable iterations.
 
-## When to Use This Skill
+**Core principle**: 100 reps beats 100 hours of study. Learning = doing better, not knowing more.
 
-Activate when the user:
-- Has a transcript/article/tutorial and wants to "implement the advice"
-- Asks to "turn this into a plan" or "make this actionable"
-- Wants to extract implementation steps from educational content
-- Needs help breaking down big ideas into small, shippable reps
-- Says things like "I watched/read X, now what should I do?"
+## Workflow
 
-## Core Framework: Ship-Learn-Next
+### 1. Read and extract actionable lessons
 
-Every learning quest follows three repeating phases:
+Read the user-provided file (transcript, article, notes) and identify:
 
-1. **SHIP** - Create something real (code, content, product, demonstration)
-2. **LEARN** - Honest reflection on what happened
-3. **NEXT** - Plan the next iteration based on learnings
+- **Actionable principles** that can be practiced
+- **Concrete techniques** or workflows mentioned
+- **Examples/case studies** to replicate
 
-**Key principle**: 100 reps beats 100 hours of study. Learning = doing better, not knowing more.
+Skip theory-only content — focus on what can be turned into action.
 
-## How This Skill Works
+### 2. Define the quest
 
-### Step 1: Read the Content
+Ask the user to frame a 4-8 week goal:
 
-Read the file the user provides (transcript, article, notes):
-
-```bash
-# User provides path to file
-FILE_PATH="/path/to/content.txt"
-```
-
-Use the Read tool to analyze the content.
-
-### Step 2: Extract Core Lessons
-
-Identify from the content:
-- **Main advice/lessons**: What are the key takeaways?
-- **Actionable principles**: What can actually be practiced?
-- **Skills being taught**: What would someone learn by doing this?
-- **Examples/case studies**: Real implementations mentioned
-
-**Do NOT**:
-- Summarize everything (focus on actionable parts)
-- List theory without application
-- Include "nice to know" vs "need to practice"
-
-### Step 3: Define the Quest
-
-Help the user frame their learning goal:
-
-Ask:
-1. "Based on this content, what do you want to achieve in 4-8 weeks?"
-2. "What would success look like? (Be specific)"
+1. "Based on this content, what do you want to achieve?"
+2. "What would success look like? Be specific."
 3. "What's something concrete you could build/create/ship?"
 
-**Example good quest**: "Ship 10 cold outreach messages and get 2 responses"
-**Example bad quest**: "Learn about sales" (too vague)
+Good quest: "Ship 10 cold outreach messages and get 2 responses"
+Bad quest: "Learn about sales" (too vague — push for specifics)
 
-### Step 4: Design Rep 1 (The First Iteration)
+### 3. Design Rep 1
 
-Break down the quest into the **smallest shippable version**:
+Break the quest into the **smallest shippable version**:
 
-Ask:
-- "What's the smallest version you could ship THIS WEEK?"
-- "What do you need to learn JUST to do that?" (not everything)
-- "What would 'done' look like for rep 1?"
-
-**Make it:**
-- Concrete and specific
 - Completable in 1-7 days
-- Produces real evidence/artifact
-- Small enough to not be intimidating
-- Big enough to learn something meaningful
+- Produces a real artifact (code, content, product)
+- Small enough to start today, big enough to learn something
 
-### Step 5: Create the Rep Plan
+Ask: "What's the smallest version you could ship THIS WEEK?"
 
-Structure each rep with:
+### 4. Create the rep plan
+
+Structure each rep using this template:
 
 ```markdown
 ## Rep 1: [Specific Goal]
 
-**Ship Goal**: [What you'll create/do]
-**Success Criteria**: [How you'll know it's done]
-**What You'll Learn**: [Specific skills/insights]
-**Resources Needed**: [Minimal - just what's needed for THIS rep]
-**Timeline**: [Specific deadline]
-
-**Action Steps**:
-1. [Concrete step 1]
-2. [Concrete step 2]
-3. [Concrete step 3]
-...
-
-**After Shipping - Reflection Questions**:
-- What actually happened? (Be specific)
-- What worked? What didn't?
-- What surprised you?
-- On a scale of 1-10, how did this rep go?
-- What would you do differently next time?
-```
-
-### Step 6: Map Future Reps (2-5)
-
-Based on the content, suggest a progression:
-
-```markdown
-## Rep 2: [Next level]
-**Builds on**: What you learned in Rep 1
-**New challenge**: One new thing to try/improve
-**Expected difficulty**: [Easier/Same/Harder - and why]
-
-## Rep 3: [Continue progression]
-...
-```
-
-**Progression principles**:
-- Each rep adds ONE new element
-- Increase difficulty based on success
-- Reference specific lessons from the content
-- Keep reps shippable (not theoretical)
-
-### Step 7: Connect to Content
-
-For each rep, reference the source material:
-
-- "This implements the [concept] from minute X"
-- "You're practicing the [technique] mentioned in the video"
-- "This tests the advice about [topic]"
-
-**But**: Always emphasize DOING over studying. Point to resources only when needed for the specific rep.
-
-## Conversation Style
-
-**Direct but supportive**:
-- No fluff, but encouraging
-- "Ship it, then we'll improve it"
-- "What's the smallest version you could do this week?"
-
-**Question-driven**:
-- Make them think, don't just tell
-- "What exactly do you want to achieve?" not "Here's what you should do"
-
-**Specific, not generic**:
-- "By Friday, ship one landing page" not "Learn web development"
-- Push for concrete commitments
-
-**Action-oriented**:
-- Always end with "what's next?"
-- Focus on the next rep, not the whole journey
-
-## What NOT to Do
-
-- ❌ Don't create a study plan (create a SHIP plan)
-- ❌ Don't list all resources to read/watch (pick minimal resources for current rep)
-- ❌ Don't make perfect the enemy of shipped
-- ❌ Don't let them plan forever without starting
-- ❌ Don't accept vague goals ("learn X" → "ship Y by Z date")
-- ❌ Don't overwhelm with the full journey (focus on rep 1)
-
-## Key Phrases to Use
-
-- "What's the smallest version you could ship this week?"
-- "What do you need to learn JUST to do that?"
-- "This isn't about perfection - it's rep 1 of 100"
-- "Ship something real, then we'll improve it"
-- "Based on [content], what would you actually DO differently?"
-- "Learning = doing better, not knowing more"
-
-## Example Output Structure
-
-```markdown
-# Your Ship-Learn-Next Quest: [Title]
-
-## Quest Overview
-**Goal**: [What they want to achieve in 4-8 weeks]
-**Source**: [The content that inspired this]
-**Core Lessons**: [3-5 key actionable takeaways from content]
-
----
-
-## Rep 1: [Specific, Shippable Goal]
-
 **Ship Goal**: [Concrete deliverable]
-**Timeline**: [This week / By [date]]
+**Timeline**: [This week / By date]
 **Success Criteria**:
-- [ ] [Specific thing 1]
-- [ ] [Specific thing 2]
-- [ ] [Specific thing 3]
+- [ ] [Measurable outcome 1]
+- [ ] [Measurable outcome 2]
 
-**What You'll Practice** (from the content):
-- [Skill/concept 1 from source material]
-- [Skill/concept 2 from source material]
+**What You'll Practice** (from the source content):
+- [Skill/concept from source material]
 
 **Action Steps**:
 1. [Concrete step]
 2. [Concrete step]
-3. [Concrete step]
-4. Ship it (publish/deploy/share/demonstrate)
+3. Ship it (publish/deploy/share/demonstrate)
 
-**Minimal Resources** (only for this rep):
-- [Link or reference - if truly needed]
-
-**After Shipping - Reflection**:
-Answer these questions:
+**After Shipping — Reflection**:
 - What actually happened?
 - What worked? What didn't?
-- What surprised you?
 - Rate this rep: _/10
 - What's one thing to try differently next time?
-
----
-
-## Rep 2: [Next Iteration]
-
-**Builds on**: Rep 1 + [what you learned]
-**New element**: [One new challenge/skill]
-**Ship goal**: [Next concrete deliverable]
-
-[Similar structure...]
-
----
-
-## Rep 3-5: Future Path
-
-**Rep 3**: [Brief description]
-**Rep 4**: [Brief description]
-**Rep 5**: [Brief description]
-
-*(Details will evolve based on what you learn in Reps 1-2)*
-
----
-
-## Remember
-
-- This is about DOING, not studying
-- Aim for 100 reps over time (not perfection on rep 1)
-- Each rep = Plan → Do → Reflect → Next
-- You learn by shipping, not by consuming
-
-**Ready to ship Rep 1?**
 ```
 
-## Processing Different Content Types
+### 5. Map future reps (2-5)
 
-### YouTube Transcripts
-- Focus on advice, not stories
-- Extract concrete techniques mentioned
-- Identify case studies/examples to replicate
-- Note timestamps for reference later (but don't require watching again)
+Suggest a progression where each rep adds ONE new element. Reference specific lessons from the source content. Keep all reps shippable, not theoretical.
 
-### Articles/Tutorials
-- Identify the "now do this" parts vs theory
-- Extract the specific workflow/process
-- Find the minimal example to start with
+```markdown
+## Rep 2: [Next level]
+**Builds on**: Rep 1 learnings
+**New challenge**: [One new element]
+**Ship goal**: [Concrete deliverable]
+```
 
-### Course Notes
-- What's the smallest project from the course?
-- Which modules are needed for rep 1? (ignore the rest for now)
-- What can be practiced immediately?
+### 6. Save and present
 
-## Success Metrics
+Save the complete plan as `Ship-Learn-Next Plan - [Brief Quest Title].md`.
 
-A good Ship-Learn-Next plan has:
-- ✅ Specific, shippable rep 1 (completable in 1-7 days)
-- ✅ Clear success criteria (user knows when they're done)
-- ✅ Concrete artifacts (something real to show)
-- ✅ Direct connection to source content
-- ✅ Progression path for reps 2-5
-- ✅ Emphasis on action over consumption
-- ✅ Honest reflection built in
-- ✅ Small enough to start today, big enough to learn
+Then:
+1. Confirm the file was saved
+2. Highlight Rep 1 and its deadline
+3. Ask: "When will you ship Rep 1?" and "What might stop you?"
 
-## Saving the Plan
+## Content-type guidelines
 
-**IMPORTANT**: Always save the plan to a file for the user.
+| Content Type | Focus On | Skip |
+|---|---|---|
+| YouTube transcripts | Concrete techniques, case studies to replicate | Stories, filler |
+| Articles/tutorials | Workflows, "do this" sections | Pure theory |
+| Course notes | Smallest project, modules needed for rep 1 | Everything else |
 
-### Filename Convention
+## Conversation style
 
-Always use the format:
-- `Ship-Learn-Next Plan - [Brief Quest Title].md`
+- **Direct but supportive**: "Ship it, then we'll improve it"
+- **Question-driven**: Make them think rather than prescribing
+- **Specific**: "By Friday, ship one landing page" not "Learn web development"
+- **Action-oriented**: Always end with "what's next?"
 
-Examples:
-- `Ship-Learn-Next Plan - Build in Proven Markets.md`
-- `Ship-Learn-Next Plan - Learn React.md`
-- `Ship-Learn-Next Plan - Cold Email Outreach.md`
+## Constraints
 
-**Quest title should be**:
-- Brief (3-6 words)
-- Descriptive of the main goal
-- Based on the content's core lesson/theme
-
-### What to Save
-
-**Complete plan including**:
-- Quest overview with goal and source
-- All reps (1-5) with full details
-- Action steps and reflection questions
-- Timeline commitments
-- Reference to source material
-
-**Format**: Always save as Markdown (`.md`) for readability
-
-## After Creating the Plan
-
-**Display to user**:
-1. Show them you've saved the plan: "✓ Saved to: [filename]"
-2. Give a brief overview of the quest
-3. Highlight Rep 1 (what's due this week)
-
-**Then ask**:
-1. "When will you ship Rep 1?"
-2. "What's the one thing that might stop you? How will you handle it?"
-3. "Come back after you ship and we'll reflect + plan Rep 2"
-
-**Remember**: You're not creating a curriculum. You're helping them ship something real, learn from it, and ship the next thing.
-
-Let's help them ship.
+- Never create a study plan — create a SHIP plan
+- Never accept vague goals — push "learn X" toward "ship Y by Z date"
+- Never overwhelm with the full journey — focus on rep 1 first
+- Pick minimal resources for the current rep only

--- a/skills/skill-judge/SKILL.md
+++ b/skills/skill-judge/SKILL.md
@@ -1,75 +1,27 @@
 ---
 name: skill-judge
-description: Evaluate Agent Skill design quality against official specifications and best practices. Use when reviewing, auditing, or improving SKILL.md files and skill packages. Provides multi-dimensional scoring and actionable improvement suggestions.
+description: Evaluate Agent Skill SKILL.md files against official specifications and best practices. Use when reviewing, auditing, scoring, or improving skill quality. Validates YAML frontmatter structure, checks description trigger terms, evaluates knowledge delta, scores progressive disclosure and file organization. Provides 8-dimension scoring (120 points) and actionable improvement suggestions for skill packages.
 ---
 
 # Skill Judge
 
-Evaluate Agent Skills against official specifications and patterns derived from 17+ official examples.
+Evaluate Agent Skills against official specifications and patterns derived from 17+ official examples. Produces an 8-dimension score (120 points) with actionable improvement guidance.
 
 ---
 
-## Core Philosophy
-
-### What is a Skill?
-
-A Skill is NOT a tutorial. A Skill is a **knowledge externalization mechanism**.
-
-Traditional AI knowledge is locked in model parameters. To teach new capabilities:
-```
-Traditional: Collect data → GPU cluster → Train → Deploy new version
-Cost: $10,000 - $1,000,000+
-Timeline: Weeks to months
-```
-
-Skills change this:
-```
-Skill: Edit SKILL.md → Save → Takes effect on next invocation
-Cost: $0
-Timeline: Instant
-```
-
-This is the paradigm shift from "training AI" to "educating AI" — like a hot-swappable LoRA adapter that requires no training. You edit a Markdown file in natural language, and the model's behavior changes.
-
-### The Core Formula
+## Core Principle
 
 > **Good Skill = Expert-only Knowledge − What Claude Already Knows**
 
-A Skill's value is measured by its **knowledge delta** — the gap between what it provides and what the model already knows.
-
-- **Expert-only knowledge**: Decision trees, trade-offs, edge cases, anti-patterns, domain-specific thinking frameworks — things that take years of experience to accumulate
-- **What Claude already knows**: Basic concepts, standard library usage, common programming patterns, general best practices
-
-When a Skill explains "what is PDF" or "how to write a for-loop", it's compressing knowledge Claude already has. This is **token waste** — context window is a public resource shared with system prompts, conversation history, other Skills, and user requests.
-
-### Tool vs Skill
-
-| Concept | Essence | Function | Example |
-|---------|---------|----------|---------|
-| **Tool** | What model CAN do | Execute actions | bash, read_file, write_file, WebSearch |
-| **Skill** | What model KNOWS how to do | Guide decisions | PDF processing, MCP building, frontend design |
-
-Tools define capability boundaries — without bash tool, model can't execute commands.
-Skills inject knowledge — without frontend-design Skill, model produces generic UI.
-
-**The equation**:
-```
-General Agent + Excellent Skill = Domain Expert Agent
-```
-
-Same Claude model, different Skills loaded, becomes different experts.
-
-### Three Types of Knowledge in Skills
-
-When evaluating, categorize each section:
+A Skill's value is its **knowledge delta**. Categorize every section:
 
 | Type | Definition | Treatment |
 |------|------------|-----------|
-| **Expert** | Claude genuinely doesn't know this | Must keep — this is the Skill's value |
+| **Expert** | Claude genuinely doesn't know this | Must keep — the Skill's value |
 | **Activation** | Claude knows but may not think of | Keep if brief — serves as reminder |
-| **Redundant** | Claude definitely knows this | Should delete — wastes tokens |
+| **Redundant** | Claude definitely knows this | Delete — wastes tokens |
 
-The art of Skill design is maximizing Expert content, using Activation sparingly, and eliminating Redundant ruthlessly.
+Target ratio: >70% Expert, <20% Activation, <10% Redundant.
 
 ---
 
@@ -77,48 +29,19 @@ The art of Skill design is maximizing Expert content, using Activation sparingly
 
 ### D1: Knowledge Delta (20 points) — THE CORE DIMENSION
 
-The most important dimension. Does the Skill add genuine expert knowledge?
-
 | Score | Criteria |
 |-------|----------|
-| 0-5 | Explains basics Claude knows (what is X, how to write code, standard library tutorials) |
+| 0-5 | Explains basics Claude knows (what is X, standard tutorials) |
 | 6-10 | Mixed: some expert knowledge diluted by obvious content |
 | 11-15 | Mostly expert knowledge with minimal redundancy |
 | 16-20 | Pure knowledge delta — every paragraph earns its tokens |
 
-**Red flags** (instant score ≤5):
-- "What is [basic concept]" sections
-- Step-by-step tutorials for standard operations
-- Explaining how to use common libraries
-- Generic best practices ("write clean code", "handle errors")
-- Definitions of industry-standard terms
-
-**Green flags** (indicators of high knowledge delta):
-- Decision trees for non-obvious choices ("when X fails, try Y because Z")
-- Trade-offs only an expert would know ("A is faster but B handles edge case C")
-- Edge cases from real-world experience
-- "NEVER do X because [non-obvious reason]"
-- Domain-specific thinking frameworks
-
-**Evaluation questions**:
-1. For each section, ask: "Does Claude already know this?"
-2. If explaining something, ask: "Is this explaining TO Claude or FOR Claude?"
-3. Count paragraphs that are Expert vs Activation vs Redundant
+**Red flags** (instant ≤5): "What is [basic concept]" sections, standard library tutorials, generic best practices.
+**Green flags**: Decision trees for non-obvious choices, expert-only trade-offs, edge cases from real-world experience, "NEVER do X because [non-obvious reason]".
 
 ---
 
 ### D2: Mindset + Appropriate Procedures (15 points)
-
-Does the Skill transfer expert **thinking patterns** along with **necessary domain-specific procedures**?
-
-The difference between experts and novices isn't "knowing how to operate" — it's "how to think about the problem." But thinking patterns alone aren't enough when Claude lacks domain-specific procedural knowledge.
-
-**Key distinction**:
-| Type | Example | Value |
-|------|---------|-------|
-| **Thinking patterns** | "Before designing, ask: What makes this memorable?" | High — shapes decision-making |
-| **Domain-specific procedures** | "OOXML workflow: unpack → edit XML → validate → pack" | High — Claude may not know this |
-| **Generic procedures** | "Step 1: Open file, Step 2: Edit, Step 3: Save" | Low — Claude already knows |
 
 | Score | Criteria |
 |-------|----------|
@@ -127,88 +50,25 @@ The difference between experts and novices isn't "knowing how to operate" — it
 | 8-11 | Good balance: thinking patterns + domain-specific workflows |
 | 12-15 | Expert-level: shapes thinking AND provides procedures Claude wouldn't know |
 
-**What counts as valuable procedures**:
-- Workflows Claude hasn't been trained on (new tools, proprietary systems)
-- Correct ordering that's non-obvious (e.g., "validate BEFORE packing, not after")
-- Critical steps that are easy to miss (e.g., "MUST recalculate formulas after editing")
-- Domain-specific sequences (e.g., MCP server's 4-phase development process)
-
-**What counts as redundant procedures**:
-- Generic file operations (open, read, write, save)
-- Standard programming patterns (loops, conditionals, error handling)
-- Common library usage that's well-documented
-
-**Expert thinking patterns look like**:
-```markdown
-Before [action], ask yourself:
-- **Purpose**: What problem does this solve? Who uses it?
-- **Constraints**: What are the hidden requirements?
-- **Differentiation**: What makes this solution memorable?
-```
-
-**Valuable domain procedures look like**:
-```markdown
-### Redlining Workflow (Claude wouldn't know this sequence)
-1. Convert to markdown: `pandoc --track-changes=all`
-2. Map text to XML: grep for text in document.xml
-3. Implement changes in batches of 3-10
-4. Pack and verify: check ALL changes were applied
-```
-
-**Redundant generic procedures look like**:
-```markdown
-Step 1: Open the file
-Step 2: Find the section
-Step 3: Make the change
-Step 4: Save and test
-```
-
-**The test**:
-1. Does it tell Claude WHAT to think about? (thinking patterns)
-2. Does it tell Claude HOW to do things it wouldn't know? (domain procedures)
-
-A good Skill provides both when needed.
+**Valuable**: Thinking patterns ("Before X, ask yourself..."), domain-specific sequences Claude hasn't been trained on, non-obvious ordering, critical easy-to-miss steps.
+**Redundant**: Generic file operations, standard programming patterns, common well-documented library usage.
 
 ---
 
 ### D3: Anti-Pattern Quality (15 points)
 
-Does the Skill have effective NEVER lists?
-
-**Why this matters**: Half of expert knowledge is knowing what NOT to do. A senior designer sees purple gradient on white background and instinctively cringes — "too AI-generated." This intuition for "what absolutely not to do" comes from stepping on countless landmines.
-
-Claude hasn't stepped on these landmines. It doesn't know Inter font is overused, doesn't know purple gradients are the signature of AI-generated content. Good Skills must explicitly state these "absolute don'ts."
-
 | Score | Criteria |
 |-------|----------|
 | 0-3 | No anti-patterns mentioned |
-| 4-7 | Generic warnings ("avoid errors", "be careful", "consider edge cases") |
+| 4-7 | Generic warnings ("avoid errors", "be careful") |
 | 8-11 | Specific NEVER list with some reasoning |
 | 12-15 | Expert-grade anti-patterns with WHY — things only experience teaches |
 
-**Expert anti-patterns** (specific + reason):
-```markdown
-NEVER use generic AI-generated aesthetics like:
-- Overused font families (Inter, Roboto, Arial)
-- Cliched color schemes (particularly purple gradients on white backgrounds)
-- Predictable layouts and component patterns
-- Default border-radius on everything
-```
-
-**Weak anti-patterns** (vague, no reasoning):
-```markdown
-Avoid making mistakes.
-Be careful with edge cases.
-Don't write bad code.
-```
-
-**The test**: Would an expert read the anti-pattern list and say "yes, I learned this the hard way"? Or would they say "this is obvious to everyone"?
+**The test**: Would an expert say "I learned this the hard way"? Or "this is obvious to everyone"?
 
 ---
 
 ### D4: Specification Compliance — Especially Description (15 points)
-
-Does the Skill follow official format requirements? **Special focus on description quality.**
 
 | Score | Criteria |
 |-------|----------|
@@ -217,97 +77,27 @@ Does the Skill follow official format requirements? **Special focus on descripti
 | 11-13 | Valid frontmatter, description has WHAT but weak on WHEN |
 | 14-15 | Perfect: comprehensive description with WHAT, WHEN, and trigger keywords |
 
-**Frontmatter requirements**:
-- `name`: lowercase, alphanumeric + hyphens only, ≤64 characters
-- `description`: **THE MOST CRITICAL FIELD** — determines if skill gets used at all
+**Why description is critical**: The Agent sees ONLY skill descriptions when deciding which to activate. A Skill with perfect content but poor description is useless — it never gets loaded.
 
----
-
-**Why description is THE MOST IMPORTANT field**:
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│  SKILL ACTIVATION FLOW                                              │
-│                                                                     │
-│  User Request → Agent sees ALL skill descriptions → Decides which  │
-│                 (only descriptions, not bodies!)     to activate    │
-│                                                                     │
-│  If description doesn't match → Skill NEVER gets loaded            │
-│  If description is vague → Skill might not trigger when it should  │
-│  If description lacks keywords → Skill is invisible to the Agent   │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-**The brutal truth**: A Skill with perfect content but poor description is **useless** — it will never be activated. The description is the **only chance** to tell the Agent "use me in these situations."
-
----
-
-**Description must answer THREE questions**:
-
-1. **WHAT**: What does this Skill do? (functionality)
+**Description must answer**:
+1. **WHAT**: What does this Skill do? (specific capabilities)
 2. **WHEN**: In what situations should it be used? (trigger scenarios)
 3. **KEYWORDS**: What terms should trigger this Skill? (searchable terms)
 
-**Excellent description** (all three elements):
-```yaml
-description: "Comprehensive document creation, editing, and analysis with support
-for tracked changes, comments, formatting preservation, and text extraction.
-When Claude needs to work with professional documents (.docx files) for:
-(1) Creating new documents, (2) Modifying or editing content,
-(3) Working with tracked changes, (4) Adding comments, or any other document tasks"
-```
-
-Analysis:
-- WHAT: creation, editing, analysis, tracked changes, comments
-- WHEN: "When Claude needs to work with... for: (1)... (2)... (3)..."
-- KEYWORDS: .docx files, tracked changes, professional documents
-
-**Poor description** (missing elements):
-```yaml
-description: "处理文档相关功能"
-```
-
-Problems:
-- WHAT: vague ("文档相关功能" — what specifically?)
-- WHEN: missing (when should Agent use this?)
-- KEYWORDS: missing (no ".docx", no specific scenarios)
-
-**Another poor example**:
-```yaml
-description: "A helpful skill for various tasks"
-```
-
-This is useless — Agent has no idea when to activate it.
-
----
-
-**Description quality checklist**:
+**Checklist**:
 - [ ] Lists specific capabilities (not just "helps with X")
 - [ ] Includes explicit trigger scenarios ("Use when...", "When user asks for...")
 - [ ] Contains searchable keywords (file extensions, domain terms, action verbs)
 - [ ] Specific enough that Agent knows EXACTLY when to use it
-- [ ] Includes scenarios where this skill MUST be used (not just "can be used")
 
 ---
 
 ### D5: Progressive Disclosure (15 points)
 
-Does the Skill implement proper content layering?
-
-Skill loading has three layers:
-```
-Layer 1: Metadata (always in memory)
-         Only name + description
-         ~100 tokens per skill
-
-Layer 2: SKILL.md Body (loaded after triggering)
-         Detailed guidelines, code examples, decision trees
-         Ideal: < 500 lines
-
-Layer 3: Resources (loaded on demand)
-         scripts/, references/, assets/
-         No limit
-```
+Three loading layers:
+- **Layer 1**: Metadata (always in memory) — name + description only (~100 tokens)
+- **Layer 2**: SKILL.md body (loaded after triggering) — ideal < 500 lines
+- **Layer 3**: Resources (loaded on demand) — scripts/, references/, assets/
 
 | Score | Criteria |
 |-------|----------|
@@ -316,40 +106,10 @@ Layer 3: Resources (loaded on demand)
 | 11-13 | Good layering with MANDATORY triggers present |
 | 14-15 | Perfect: decision trees + explicit triggers + "Do NOT Load" guidance |
 
-**For Skills WITH references directory**, check Loading Trigger Quality:
-
-| Trigger Quality | Characteristics |
-|-----------------|-----------------|
-| Poor | References listed at end, no loading guidance |
-| Mediocre | Some triggers but not embedded in workflow |
-| Good | MANDATORY triggers in workflow steps |
-| Excellent | Scenario detection + conditional triggers + "Do NOT Load" |
-
-**The loading problem**:
-```
-Loading too little ◄─────────────────────────────────► Loading too much
-- References sit unused                    - Wastes context space
-- Agent doesn't know when to load          - Irrelevant info dilutes key content
-- Knowledge is there but never accessed    - Unnecessary token overhead
-```
-
 **Good loading trigger** (embedded in workflow):
 ```markdown
-### Creating New Document
-
 **MANDATORY - READ ENTIRE FILE**: Before proceeding, you MUST read
-[`docx-js.md`](docx-js.md) (~500 lines) completely from start to finish.
-**NEVER set any range limits when reading this file.**
-
-**Do NOT load** `ooxml.md` or `redlining.md` for this task.
-```
-
-**Bad loading trigger** (just listed):
-```markdown
-## References
-- docx-js.md - for creating documents
-- ooxml.md - for editing
-- redlining.md - for tracking changes
+[`docx-js.md`](docx-js.md) completely. **Do NOT load** `ooxml.md` for this task.
 ```
 
 **For simple Skills** (no references, <100 lines): Score based on conciseness and self-containment.
@@ -358,66 +118,34 @@ Loading too little ◄───────────────────�
 
 ### D6: Freedom Calibration (15 points)
 
-Is the level of specificity appropriate for the task's fragility?
+Match constraint level to task fragility:
 
-Different tasks need different levels of constraint. This is about matching freedom to fragility.
+| Task Type | Freedom Level | Why |
+|-----------|---------------|-----|
+| Creative/Design | High (principles, not steps) | Multiple valid approaches |
+| Code review | Medium (priorities + judgment) | Principles exist but judgment required |
+| File format operations | Low (exact scripts) | One wrong byte corrupts file |
 
 | Score | Criteria |
 |-------|----------|
-| 0-5 | Severely mismatched (rigid scripts for creative tasks, vague for fragile ops) |
-| 6-10 | Partially appropriate, some mismatches |
+| 0-5 | Severely mismatched (rigid for creative, vague for fragile) |
+| 6-10 | Partially appropriate |
 | 11-13 | Good calibration for most scenarios |
 | 14-15 | Perfect freedom calibration throughout |
-
-**The freedom spectrum**:
-
-| Task Type | Should Have | Why | Example Skill |
-|-----------|-------------|-----|---------------|
-| Creative/Design | High freedom | Multiple valid approaches, differentiation is value | frontend-design |
-| Code review | Medium freedom | Principles exist but judgment required | code-review |
-| File format operations | Low freedom | One wrong byte corrupts file, consistency critical | docx, xlsx, pdf |
-
-**High freedom** (text-based instructions):
-```markdown
-Commit to a BOLD aesthetic direction. Pick an extreme: brutally minimal,
-maximalist chaos, retro-futuristic, organic natural...
-```
-
-**Medium freedom** (pseudocode or parameterized):
-```markdown
-Review priority:
-1. Security vulnerabilities (must fix)
-2. Logic errors (must fix)
-3. Performance issues (should fix)
-4. Maintainability (optional)
-```
-
-**Low freedom** (specific scripts, exact steps):
-```markdown
-**MANDATORY**: Use exact script in `scripts/create-doc.py`
-Parameters: --title "X" --author "Y"
-Do NOT modify the script.
-```
-
-**The test**: Ask "if Agent makes a mistake, what's the consequence?"
-- High consequence → Low freedom
-- Low consequence → High freedom
 
 ---
 
 ### D7: Pattern Recognition (10 points)
 
-Does the Skill follow an established official pattern?
+Five official patterns identified across 17 Skills:
 
-Through analyzing 17 official Skills, we identified 5 main design patterns:
-
-| Pattern | ~Lines | Key Characteristics | Example | When to Use |
-|---------|--------|---------------------|---------|-------------|
-| **Mindset** | ~50 | Thinking > technique, strong NEVER list, high freedom | frontend-design | Creative tasks requiring taste |
-| **Navigation** | ~30 | Minimal SKILL.md, routes to sub-files | internal-comms | Multiple distinct scenarios |
-| **Philosophy** | ~150 | Two-step: Philosophy → Express, emphasizes craft | canvas-design | Art/creation requiring originality |
-| **Process** | ~200 | Phased workflow, checkpoints, medium freedom | mcp-builder | Complex multi-step projects |
-| **Tool** | ~300 | Decision trees, code examples, low freedom | docx, pdf, xlsx | Precise operations on specific formats |
+| Pattern | ~Lines | When to Use |
+|---------|--------|-------------|
+| **Mindset** | ~50 | Creative tasks requiring taste |
+| **Navigation** | ~30 | Multiple distinct scenarios |
+| **Philosophy** | ~150 | Art/creation requiring originality |
+| **Process** | ~200 | Complex multi-step projects |
+| **Tool** | ~300 | Precise operations on specific formats |
 
 | Score | Criteria |
 |-------|----------|
@@ -426,21 +154,9 @@ Through analyzing 17 official Skills, we identified 5 main design patterns:
 | 7-8 | Clear pattern with minor deviations |
 | 9-10 | Masterful application of appropriate pattern |
 
-**Pattern selection guide**:
-
-| Your Task Characteristics | Recommended Pattern |
-|---------------------------|---------------------|
-| Needs taste and creativity | Mindset (~50 lines) |
-| Needs originality and craft quality | Philosophy (~150 lines) |
-| Has multiple distinct sub-scenarios | Navigation (~30 lines) |
-| Complex multi-step project | Process (~200 lines) |
-| Precise operations on specific format | Tool (~300 lines) |
-
 ---
 
 ### D8: Practical Usability (15 points)
-
-Can an Agent actually use this Skill effectively?
 
 | Score | Criteria |
 |-------|----------|
@@ -449,31 +165,7 @@ Can an Agent actually use this Skill effectively?
 | 11-13 | Clear guidance for common cases |
 | 14-15 | Comprehensive coverage including edge cases and error handling |
 
-**Check for**:
-- **Decision trees**: For multi-path scenarios, is there clear guidance on which path to take?
-- **Code examples**: Do they actually work? Or are they pseudocode that breaks?
-- **Error handling**: What if the main approach fails? Are fallbacks provided?
-- **Edge cases**: Are unusual but realistic scenarios covered?
-- **Actionability**: Can Agent immediately act, or needs to figure things out?
-
-**Good usability** (decision tree + fallback):
-```markdown
-| Task | Primary Tool | Fallback | When to Use Fallback |
-|------|-------------|----------|----------------------|
-| Read text | pdftotext | PyMuPDF | Need layout info |
-| Extract tables | camelot-py | tabula-py | camelot fails |
-
-**Common issues**:
-- Scanned PDF: pdftotext returns blank → Use OCR first
-- Encrypted PDF: Permission error → Use PyMuPDF with password
-```
-
-**Poor usability** (vague):
-```markdown
-Use appropriate tools for PDF processing.
-Handle errors properly.
-Consider edge cases.
-```
+**Check for**: Decision trees for multi-path scenarios, working code examples, error handling/fallbacks, edge case coverage, immediate actionability.
 
 ---
 
@@ -482,9 +174,9 @@ Consider edge cases.
 - **NEVER** give high scores just because it "looks professional" or is well-formatted
 - **NEVER** ignore token waste — every redundant paragraph should result in deduction
 - **NEVER** let length impress you — a 43-line Skill can outperform a 500-line Skill
-- **NEVER** skip mentally testing the decision trees — do they actually lead to correct choices?
+- **NEVER** skip mentally testing decision trees — do they lead to correct choices?
 - **NEVER** forgive explaining basics with "but it provides helpful context"
-- **NEVER** overlook missing anti-patterns — if there's no NEVER list, that's a significant gap
+- **NEVER** overlook missing anti-patterns — no NEVER list is a significant gap
 - **NEVER** assume all procedures are valuable — distinguish domain-specific from generic
 - **NEVER** undervalue the description field — poor description = skill never gets used
 - **NEVER** put "when to use" info only in the body — Agent only sees description before loading
@@ -493,46 +185,20 @@ Consider edge cases.
 
 ## Evaluation Protocol
 
-### Step 1: First Pass — Knowledge Delta Scan
+### Step 1: Knowledge Delta Scan
 
-Read SKILL.md completely and for each section ask:
-> "Does Claude already know this?"
-
-Mark each section as:
-- **[E] Expert**: Claude genuinely doesn't know this — value-add
-- **[A] Activation**: Claude knows but brief reminder is useful — acceptable
-- **[R] Redundant**: Claude definitely knows this — should be deleted
-
-Calculate rough ratio: E:A:R
-- Good Skill: >70% Expert, <20% Activation, <10% Redundant
-- Mediocre Skill: 40-70% Expert, high Activation
-- Bad Skill: <40% Expert, high Redundant
+Read SKILL.md completely. Mark each section as **[E] Expert**, **[A] Activation**, or **[R] Redundant**. Calculate the E:A:R ratio.
 
 ### Step 2: Structure Analysis
 
-```
-[ ] Check frontmatter validity
-[ ] Count total lines in SKILL.md
-[ ] List all reference files and their sizes
-[ ] Identify which pattern the Skill follows
-[ ] Check for loading triggers (if references exist)
-```
+Check frontmatter validity, count lines, list reference files and sizes, identify pattern, check loading triggers.
 
 ### Step 3: Score Each Dimension
 
-For each of the 8 dimensions:
-1. Find specific evidence (quote relevant lines)
-2. Assign score with one-line justification
-3. Note specific improvements if score < max
+For each of the 8 dimensions: find specific evidence, assign score with justification, note improvements if below max.
 
 ### Step 4: Calculate Total & Grade
 
-```
-Total = D1 + D2 + D3 + D4 + D5 + D6 + D7 + D8
-Max = 120 points
-```
-
-**Grade Scale** (percentage-based):
 | Grade | Percentage | Meaning |
 |-------|------------|---------|
 | A | 90%+ (108+) | Excellent — production-ready expert Skill |
@@ -567,186 +233,28 @@ Max = 120 points
 | D8: Practical Usability | X | 15 | |
 
 ## Critical Issues
-[List must-fix problems that significantly impact the Skill's effectiveness]
+[Must-fix problems that significantly impact effectiveness]
 
 ## Top 3 Improvements
 1. [Highest impact improvement with specific guidance]
 2. [Second priority improvement]
 3. [Third priority improvement]
-
-## Detailed Analysis
-[For each dimension scoring below 80%, provide:
-- What's missing or problematic
-- Specific examples from the Skill
-- Concrete suggestions for improvement]
 ```
 
 ---
 
-## Common Failure Patterns
+## References
 
-### Pattern 1: The Tutorial
-```
-Symptom: Explains what PDF is, how Python works, basic library usage
-Root cause: Author assumes Skill should "teach" the model
-Fix: Claude already knows this. Delete all basic explanations.
-     Focus on expert decisions, trade-offs, and anti-patterns.
-```
+**MANDATORY** — When encountering a recurring failure pattern during evaluation, read [`references/failure-patterns.md`](references/failure-patterns.md) for detailed diagnosis and fix guidance covering 9 common anti-patterns (The Tutorial, The Dump, The Orphan References, The Checkbox Procedure, The Vague Warning, The Invisible Skill, The Wrong Location, The Over-Engineered, The Freedom Mismatch).
 
-### Pattern 2: The Dump
-```
-Symptom: SKILL.md is 800+ lines with everything included
-Root cause: No progressive disclosure design
-Fix: Core routing and decision trees in SKILL.md (<300 lines ideal)
-     Detailed content in references/, loaded on-demand
-```
+**MANDATORY** — For quick validation during Step 2 (Structure Analysis), read [`references/checklist.md`](references/checklist.md) for a comprehensive per-dimension checkbox reference.
 
-### Pattern 3: The Orphan References
-```
-Symptom: References directory exists but files are never loaded
-Root cause: No explicit loading triggers
-Fix: Add "MANDATORY - READ ENTIRE FILE" at workflow decision points
-     Add "Do NOT Load" to prevent over-loading
-```
-
-### Pattern 4: The Checkbox Procedure
-```
-Symptom: Step 1, Step 2, Step 3... mechanical procedures
-Root cause: Author thinks in procedures, not thinking frameworks
-Fix: Transform into "Before doing X, ask yourself..."
-     Focus on decision principles, not operation sequences
-```
-
-### Pattern 5: The Vague Warning
-```
-Symptom: "Be careful", "avoid errors", "consider edge cases"
-Root cause: Author knows things can go wrong but hasn't articulated specifics
-Fix: Specific NEVER list with concrete examples and non-obvious reasons
-     "NEVER use X because [specific problem that takes experience to learn]"
-```
-
-### Pattern 6: The Invisible Skill
-```
-Symptom: Great content but skill rarely gets activated
-Root cause: Description is vague, missing keywords, or lacks trigger scenarios
-Fix: Description must answer WHAT, WHEN, and include KEYWORDS
-     "Use when..." + specific scenarios + searchable terms
-
-Example fix:
-BAD:  "Helps with document tasks"
-GOOD: "Create, edit, and analyze .docx files. Use when working with
-       Word documents, tracked changes, or professional document formatting."
-```
-
-### Pattern 7: The Wrong Location
-```
-Symptom: "When to use this Skill" section in body, not in description
-Root cause: Misunderstanding of three-layer loading
-Fix: Move all triggering information to description field
-     Body is only loaded AFTER triggering decision is made
-```
-
-### Pattern 8: The Over-Engineered
-```
-Symptom: README.md, CHANGELOG.md, INSTALLATION_GUIDE.md, CONTRIBUTING.md
-Root cause: Treating Skill like a software project
-Fix: Delete all auxiliary files. Only include what Agent needs for the task.
-     No documentation about the Skill itself.
-```
-
-### Pattern 9: The Freedom Mismatch
-```
-Symptom: Rigid scripts for creative tasks, vague guidance for fragile operations
-Root cause: Not considering task fragility
-Fix: High freedom for creative (principles, not steps)
-     Low freedom for fragile (exact scripts, no parameters)
-```
-
----
-
-## Quick Reference Checklist
-
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│  SKILL EVALUATION QUICK CHECK                                           │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                         │
-│  KNOWLEDGE DELTA (most important):                                      │
-│    [ ] No "What is X" explanations for basic concepts                   │
-│    [ ] No step-by-step tutorials for standard operations                │
-│    [ ] Has decision trees for non-obvious choices                       │
-│    [ ] Has trade-offs only experts would know                           │
-│    [ ] Has edge cases from real-world experience                        │
-│                                                                         │
-│  MINDSET + PROCEDURES:                                                  │
-│    [ ] Transfers thinking patterns (how to think about problems)        │
-│    [ ] Has "Before doing X, ask yourself..." frameworks                 │
-│    [ ] Includes domain-specific procedures Claude wouldn't know         │
-│    [ ] Distinguishes valuable procedures from generic ones              │
-│                                                                         │
-│  ANTI-PATTERNS:                                                         │
-│    [ ] Has explicit NEVER list                                          │
-│    [ ] Anti-patterns are specific, not vague                            │
-│    [ ] Includes WHY (non-obvious reasons)                               │
-│                                                                         │
-│  SPECIFICATION (description is critical!):                              │
-│    [ ] Valid YAML frontmatter                                           │
-│    [ ] name: lowercase, ≤64 chars                                       │
-│    [ ] description answers: WHAT does it do?                            │
-│    [ ] description answers: WHEN should it be used?                     │
-│    [ ] description contains trigger KEYWORDS                            │
-│    [ ] description is specific enough for Agent to know when to use     │
-│                                                                         │
-│  STRUCTURE:                                                             │
-│    [ ] SKILL.md < 500 lines (ideal < 300)                               │
-│    [ ] Heavy content in references/                                     │
-│    [ ] Loading triggers embedded in workflow                            │
-│    [ ] Has "Do NOT Load" for preventing over-loading                    │
-│                                                                         │
-│  FREEDOM:                                                               │
-│    [ ] Creative tasks → High freedom (principles)                       │
-│    [ ] Fragile operations → Low freedom (exact scripts)                 │
-│                                                                         │
-│  USABILITY:                                                             │
-│    [ ] Decision trees for multi-path scenarios                          │
-│    [ ] Working code examples                                            │
-│    [ ] Error handling and fallbacks                                     │
-│    [ ] Edge cases covered                                               │
-│                                                                         │
-└─────────────────────────────────────────────────────────────────────────┘
-```
+**Do NOT load** reference files for simple evaluations where the skill clearly follows good patterns and scores above 80%.
 
 ---
 
 ## The Meta-Question
 
-When evaluating any Skill, always return to this fundamental question:
+> **"Would an expert in this domain say: 'Yes, this captures knowledge that took me years to learn'?"**
 
-> **"Would an expert in this domain, looking at this Skill, say:**
-> **'Yes, this captures knowledge that took me years to learn'?"**
-
-If the answer is yes → the Skill has genuine value.
-If the answer is no → it's compressing what Claude already knows.
-
-The best Skills are **compressed expert brains** — they take a designer's 10 years of aesthetic accumulation and compress it into 43 lines, or a document expert's operational experience into a 200-line decision tree.
-
-What gets compressed must be things Claude doesn't have. Otherwise, it's garbage compression.
-
----
-
-## Self-Evaluation Note
-
-This Skill (skill-judge) should itself pass evaluation:
-
-- **Knowledge Delta**: Provides specific evaluation criteria Claude wouldn't generate on its own
-- **Mindset**: Shapes how to think about Skill quality, not just checklist items
-- **Anti-Patterns**: "NEVER Do When Evaluating" section with specific don'ts
-- **Specification**: Valid frontmatter with comprehensive description
-- **Progressive Disclosure**: Self-contained, no external references needed
-- **Freedom**: Medium freedom appropriate for evaluation task
-- **Pattern**: Follows Tool pattern with decision frameworks
-- **Usability**: Clear protocol, report template, quick reference
-
-
-
-Evaluate this Skill against itself as a calibration exercise.
+If yes — the Skill has genuine value. If no — it's compressing what Claude already knows.

--- a/skills/skill-judge/references/checklist.md
+++ b/skills/skill-judge/references/checklist.md
@@ -1,0 +1,51 @@
+# Skill Evaluation Quick Reference Checklist
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  SKILL EVALUATION QUICK CHECK                                           │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  KNOWLEDGE DELTA (most important):                                      │
+│    [ ] No "What is X" explanations for basic concepts                   │
+│    [ ] No step-by-step tutorials for standard operations                │
+│    [ ] Has decision trees for non-obvious choices                       │
+│    [ ] Has trade-offs only experts would know                           │
+│    [ ] Has edge cases from real-world experience                        │
+│                                                                         │
+│  MINDSET + PROCEDURES:                                                  │
+│    [ ] Transfers thinking patterns (how to think about problems)        │
+│    [ ] Has "Before doing X, ask yourself..." frameworks                 │
+│    [ ] Includes domain-specific procedures Claude wouldn't know         │
+│    [ ] Distinguishes valuable procedures from generic ones              │
+│                                                                         │
+│  ANTI-PATTERNS:                                                         │
+│    [ ] Has explicit NEVER list                                          │
+│    [ ] Anti-patterns are specific, not vague                            │
+│    [ ] Includes WHY (non-obvious reasons)                               │
+│                                                                         │
+│  SPECIFICATION (description is critical!):                              │
+│    [ ] Valid YAML frontmatter                                           │
+│    [ ] name: lowercase, ≤64 chars                                       │
+│    [ ] description answers: WHAT does it do?                            │
+│    [ ] description answers: WHEN should it be used?                     │
+│    [ ] description contains trigger KEYWORDS                            │
+│    [ ] description is specific enough for Agent to know when to use     │
+│                                                                         │
+│  STRUCTURE:                                                             │
+│    [ ] SKILL.md < 500 lines (ideal < 300)                               │
+│    [ ] Heavy content in references/                                     │
+│    [ ] Loading triggers embedded in workflow                            │
+│    [ ] Has "Do NOT Load" for preventing over-loading                    │
+│                                                                         │
+│  FREEDOM:                                                               │
+│    [ ] Creative tasks → High freedom (principles)                       │
+│    [ ] Fragile operations → Low freedom (exact scripts)                 │
+│                                                                         │
+│  USABILITY:                                                             │
+│    [ ] Decision trees for multi-path scenarios                          │
+│    [ ] Working code examples                                            │
+│    [ ] Error handling and fallbacks                                     │
+│    [ ] Edge cases covered                                               │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```

--- a/skills/skill-judge/references/failure-patterns.md
+++ b/skills/skill-judge/references/failure-patterns.md
@@ -1,0 +1,78 @@
+# Common Failure Patterns
+
+### Pattern 1: The Tutorial
+```
+Symptom: Explains what PDF is, how Python works, basic library usage
+Root cause: Author assumes Skill should "teach" the model
+Fix: Claude already knows this. Delete all basic explanations.
+     Focus on expert decisions, trade-offs, and anti-patterns.
+```
+
+### Pattern 2: The Dump
+```
+Symptom: SKILL.md is 800+ lines with everything included
+Root cause: No progressive disclosure design
+Fix: Core routing and decision trees in SKILL.md (<300 lines ideal)
+     Detailed content in references/, loaded on-demand
+```
+
+### Pattern 3: The Orphan References
+```
+Symptom: References directory exists but files are never loaded
+Root cause: No explicit loading triggers
+Fix: Add "MANDATORY - READ ENTIRE FILE" at workflow decision points
+     Add "Do NOT Load" to prevent over-loading
+```
+
+### Pattern 4: The Checkbox Procedure
+```
+Symptom: Step 1, Step 2, Step 3... mechanical procedures
+Root cause: Author thinks in procedures, not thinking frameworks
+Fix: Transform into "Before doing X, ask yourself..."
+     Focus on decision principles, not operation sequences
+```
+
+### Pattern 5: The Vague Warning
+```
+Symptom: "Be careful", "avoid errors", "consider edge cases"
+Root cause: Author knows things can go wrong but hasn't articulated specifics
+Fix: Specific NEVER list with concrete examples and non-obvious reasons
+     "NEVER use X because [specific problem that takes experience to learn]"
+```
+
+### Pattern 6: The Invisible Skill
+```
+Symptom: Great content but skill rarely gets activated
+Root cause: Description is vague, missing keywords, or lacks trigger scenarios
+Fix: Description must answer WHAT, WHEN, and include KEYWORDS
+     "Use when..." + specific scenarios + searchable terms
+
+Example fix:
+BAD:  "Helps with document tasks"
+GOOD: "Create, edit, and analyze .docx files. Use when working with
+       Word documents, tracked changes, or professional document formatting."
+```
+
+### Pattern 7: The Wrong Location
+```
+Symptom: "When to use this Skill" section in body, not in description
+Root cause: Misunderstanding of three-layer loading
+Fix: Move all triggering information to description field
+     Body is only loaded AFTER triggering decision is made
+```
+
+### Pattern 8: The Over-Engineered
+```
+Symptom: README.md, CHANGELOG.md, INSTALLATION_GUIDE.md, CONTRIBUTING.md
+Root cause: Treating Skill like a software project
+Fix: Delete all auxiliary files. Only include what Agent needs for the task.
+     No documentation about the Skill itself.
+```
+
+### Pattern 9: The Freedom Mismatch
+```
+Symptom: Rigid scripts for creative tasks, vague guidance for fragile operations
+Root cause: Not considering task fragility
+Fix: High freedom for creative (principles, not steps)
+     Low freedom for fragile (exact scripts, no parameters)
+```

--- a/skills/web-to-markdown/SKILL.md
+++ b/skills/web-to-markdown/SKILL.md
@@ -1,77 +1,52 @@
 ---
 name: web-to-markdown
-description: "Use ONLY when the user explicitly says: 'use the skill web-to-markdown ...' (or 'use a skill web-to-markdown ...'). Converts webpage URLs to clean Markdown by calling the local web2md CLI (Puppeteer + Readability), suitable for JS-rendered pages."
+description: "Use when the user wants to scrape a webpage, convert a URL to markdown, fetch website content as text, or extract page text for reading. Converts webpage URLs to clean Markdown by calling the local web2md CLI (Puppeteer + Readability), handling JS-rendered pages, login walls, and batch URL conversion."
 metadata:
   version: 0.1.0
 ---
 
 # web-to-markdown
 
-Convert web pages to clean Markdown by driving a locally installed browser (via `web2md`).
-
-## Hard trigger gate (must enforce)
-
-This skill MUST NOT be used unless the user explicitly wrote **exactly** a phrase like:
-- `use the skill web-to-markdown ...`
-- `use a skill web-to-markdown ...`
-
-If the user did not explicitly request this skill by name, stop and ask them to re-issue the request including: `use the skill web-to-markdown`.
-
-## What this skill does
-
-- Handles JS-rendered pages (Puppeteer → user Chrome).
-- Works best with Chromium-family browsers (Chrome/Chromium/Brave/Edge) via `puppeteer-core`.
-- Extracts main content (Readability).
-- Converts to Markdown (Turndown) with cleaned links and optional YAML frontmatter.
+Convert web pages to clean Markdown using the `web2md` CLI. Handles JS-rendered pages via Puppeteer, extracts main content with Readability, and outputs clean Markdown with Turndown.
 
 ## Non-goals
 
-- Do not use Playwright or other browser automation stacks; the mechanism is `web2md`.
+- Do not use Playwright or other browser automation stacks; always use `web2md`.
 
-## Inputs you should collect (ask only if missing)
+## Inputs (ask only if missing)
 
 - `url` (or a list of URLs)
-- Output preference:
-  - Print to stdout (`--print`), OR
-  - Save to a file (`--out ./file.md`), OR
-  - Save to a directory (`--out ./some-dir/` to auto-name by page title)
-- Optional rendering controls for tricky pages:
-  - `--chrome-path <path>` (if Chrome auto-detection fails)
-  - `--interactive` (show Chrome and pause so the user can complete human checks/login, then press Enter)
-  - `--wait-until load|domcontentloaded|networkidle0|networkidle2`
-  - `--wait-for '<css selector>'`
-  - `--wait-ms <milliseconds>`
-  - `--headful` (debug)
-  - `--no-sandbox` (sometimes required in containers/CI)
-  - `--user-data-dir <dir>` (login/session; use a dedicated profile directory)
+- Output preference: print to stdout (`--print`), save to file (`--out ./file.md`), or save to directory (`--out ./dir/`)
 
 ## Workflow
 
-1) Confirm the user explicitly invoked the skill (`use the skill web-to-markdown`).
-2) Validate URL(s) start with `http://` or `https://`.
-3) Ensure `web2md` is installed:
+1. Validate URL(s) start with `http://` or `https://`.
+2. Ensure `web2md` is installed:
    - Run: `command -v web2md`
-   - If missing, instruct the user to install it (assume the project exists at `~/workspace/softaworks/projects/web2md`):
-     - `cd ~/workspace/softaworks/projects/web2md && npm install && npm run build && npm link`
-     - Or: `cd ~/workspace/softaworks/projects/web2md && npm install && npm run build && npm install -g .`
-4) Convert:
-   - Single URL → file:
-     - `web2md '<url>' --out ./page.md`
-   - Single URL → auto-named file in directory:
-     - `mkdir -p ./out && web2md '<url>' --out ./out/`
-   - Human verification / login walls (interactive):
-     - `mkdir -p ./out && web2md '<url>' --interactive --user-data-dir ./tmp/web2md-profile --out ./out/`
-     - Then: complete the check in the browser window and press Enter in the terminal to continue.
-   - Print to stdout:
-     - `web2md '<url>' --print`
-   - Multiple URLs (batch):
-     - Create output dir (e.g. `./out/`) then run one `web2md` command per URL using `--out ./out/`
-5) Validate output:
-   - If writing files, verify they exist and are non-empty (e.g. `ls -la <path>` and `wc -c <path>`).
-6) Return:
-   - The saved file path(s), or the Markdown (stdout mode).
+   - If missing, instruct the user to install from `~/workspace/softaworks/projects/web2md`:
+     ```bash
+     cd ~/workspace/softaworks/projects/web2md && npm install && npm run build && npm link
+     ```
+3. Convert using the appropriate pattern:
+   - **Single URL to file:** `web2md '<url>' --out ./page.md`
+   - **Auto-named in directory:** `mkdir -p ./out && web2md '<url>' --out ./out/`
+   - **Login walls / human verification:** `web2md '<url>' --interactive --user-data-dir ./tmp/web2md-profile --out ./out/`
+   - **Print to stdout:** `web2md '<url>' --print`
+   - **Batch (multiple URLs):** Create output dir, then run one `web2md` command per URL with `--out ./out/`
+4. Validate output: verify files exist and are non-empty (`ls -la <path>` and `wc -c <path>`).
+5. Return the saved file path(s), or the Markdown content (stdout mode).
 
-## Defaults (recommended)
+## Rendering controls (for tricky pages)
 
-- For most pages: `--wait-until networkidle2`
-- For heavy apps: start with `--wait-until domcontentloaded --wait-ms 2000`, then add `--wait-for 'main'` (or another stable selector) if needed.
+Use these flags when pages don't render correctly with defaults:
+
+| Flag | Purpose |
+|------|---------|
+| `--wait-until networkidle2` | Default; wait for network to settle |
+| `--wait-until domcontentloaded --wait-ms 2000` | Heavy apps; add `--wait-for 'main'` if needed |
+| `--chrome-path <path>` | Override Chrome auto-detection |
+| `--interactive` | Pause for human login/captcha completion |
+| `--wait-for '<selector>'` | Wait for a specific CSS selector |
+| `--headful` | Show browser window for debugging |
+| `--no-sandbox` | Required in some containers/CI environments |
+| `--user-data-dir <dir>` | Persist login sessions across runs |

--- a/skills/writing-clearly-and-concisely/SKILL.md
+++ b/skills/writing-clearly-and-concisely/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-clearly-and-concisely
-description: Use when writing prose humans will read—documentation, commit messages, error messages, explanations, reports, or UI text. Applies Strunk's timeless rules for clearer, stronger, more professional writing.
+description: Eliminate passive voice, remove unnecessary words, tighten sentence structure, and cut AI puffery from prose. Use when writing or editing documentation, commit messages, error messages, explanations, reports, or UI text. Applies Strunk's rules for clearer, stronger, more professional writing.
 ---
 
 # Writing Clearly and Concisely
@@ -85,6 +85,14 @@ LLMs regress to statistical means, producing generic, puffy prose. Avoid:
 - **Formatting overuse:** excessive bullets, emoji decorations, bold on every other word
 
 Be specific, not grandiose. Say what it actually does.
+
+### Before/After Examples
+
+| Before | After | Rule Applied |
+|--------|-------|-------------|
+| "The configuration was updated by the team" | "The team updated the configuration" | Active voice (Rule 10) |
+| "There are many developers who prefer TypeScript" | "Many developers prefer TypeScript" | Omit needless words (Rule 13) |
+| "This groundbreaking solution leverages cutting-edge technology to deliver a seamless experience" | "This tool uses WebSockets to sync data in real time" | Remove puffery, be specific (Rule 12) |
 
 For comprehensive research on why these patterns occur, see `signs-of-ai-writing.md`. Wikipedia editors developed this guide to detect AI-generated submissions — their patterns are well-documented and field-tested.
 


### PR DESCRIPTION
Hullo @leonardocouy 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the ten with the most improvements:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/e1fa1fb3-688a-4609-b3ad-64f75f30fee7" />

Here's the full before/after in text form:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| ship-learn-next | 0% | 95% | +95% |
| humanizer | 0% | 89% | +89% |
| domain-name-brainstormer | 34% | 100% | +66% |
| naming-analyzer | 45% | 100% | +55% |
| qa-test-planner | 50% | 100% | +50% |
| design-system-starter | 39% | 85% | +46% |
| requirements-clarity | 63% | 96% | +33% |
| agent-md-refactor | 76% | 100% | +24% |
| gepetto | 76% | 100% | +24% |
| reducing-entropy | 80% | 100% | +20% |
| codex | 77% | 96% | +19% |
| skill-judge | 73% | 93% | +20% |
| web-to-markdown | 81% | 100% | +19% |
| dependency-updater | 76% | 93% | +17% |
| database-schema-designer | 76% | 93% | +17% |
| c4-architecture | 86% | 100% | +14% |
| game-changing-features | 80% | 93% | +13% |
| gemini | 76% | 89% | +13% |
| professional-communication | 81% | 93% | +12% |
| react-useeffect | 88% | 100% | +12% |
| writing-clearly-and-concisely | 84% | 96% | +12% | | marp-slide | 89% | 100% | +11% |
| crafting-effective-readmes | 84% | 93% | +9% |
| frontend-to-backend-requirements | 80% | 89% | +9% | | openapi-to-typescript | 83% | 89% | +6% |
| excalidraw | 84% | 89% | +5% |
| difficult-workplace-conversations | 88% | 93% | +5% | | daily-meeting-update | 89% | 93% | +4% |
| backend-to-frontend-handoff-docs | 84% | 86% | +2% |

<details>
<summary>Changes made</summary>

**Validation fixes (0% skills)**
- `humanizer` / `ship-learn-next`: Fixed `allowed-tools` from YAML array to comma-separated string (validation failure blocked all scoring). Also removed unknown `version` frontmatter key.

**Description improvements (most skills)**
- Added explicit "Use when..." clauses with natural trigger terms users would actually say
- Added specific concrete actions to descriptions (not just generic capability statements)
- Improved distinctiveness to reduce conflict risk with similar skills

**Content improvements**
- Removed verbose explanations of concepts Claude already knows (semantic versioning, database normalization, QA fundamentals, design system philosophy, etc.)
- Consolidated redundant sections (duplicate warnings, overlapping rules, repeated examples)
- Added validation checkpoints to workflows where missing
- Added concrete before/after code examples (react-useeffect, writing-clearly-and-concisely)
- Restructured bloated skills into concise workflows (domain-name-brainstormer: 213→72 lines, qa-test-planner: 758→278 lines, naming-analyzer: 352→117 lines, skill-judge: 753→261 lines)

**Progressive disclosure**
- Extracted heavy reference content to separate files where it improved token efficiency (skill-judge references, daily-meeting-update examples, game-changing-features categories)

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏