### PR TITLE
Add OpenPackage manifest

### DIFF
--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,0 +1,10 @@
+name: agent-toolkit
+version: 1.0.10
+description: Curated collection of skills for AI coding agents. Extends agent capabilities across development, documentation, planning, and professional workflows.
+author: leonardocouy
+license: MIT
+
+includes:
+  - skills/**/*
+  - agents/**/*
+  - commands/**/*


### PR DESCRIPTION
Enables installation via opkg install agent-toolkit

Adds openpackage.yml manifest for opkg compatibility.