### PR TITLE
fix: match heading depths 1-6 in session-handoff validator

### DIFF
--- a/skills/session-handoff/scripts/validate_handoff.py
+++ b/skills/session-handoff/scripts/validate_handoff.py
@@ -64,15 +64,15 @@ def check_required_sections(content: str) -> tuple[bool, list[str]]:
     """Check that required sections exist and have content."""
     missing = []
     for section in REQUIRED_SECTIONS:
-        # Look for section header
-        pattern = rf'(?:^|\n)##?\s*{re.escape(section)}'
+        # Look for section header at any heading depth (# through ######)
+        pattern = rf'(?:^|\n)#{{1,6}}\s*{re.escape(section)}'
         match = re.search(pattern, content, re.IGNORECASE)
         if not match:
             missing.append(f"{section} (missing)")
         else:
             # Check if section has meaningful content (not just placeholder)
             section_start = match.end()
-            next_section = re.search(r'\n##?\s+', content[section_start:])
+            next_section = re.search(r'\n#{1,6}\s+', content[section_start:])
             section_end = section_start + next_section.start() if next_section else len(content)
             section_content = content[section_start:section_end].strip()
 
@@ -87,7 +87,7 @@ def check_recommended_sections(content: str) -> list[str]:
     """Check which recommended sections are missing."""
     missing = []
     for section in RECOMMENDED_SECTIONS:
-        pattern = rf'(?:^|\n)##?\s*{re.escape(section)}'
+        pattern = rf'(?:^|\n)#{{1,6}}\s*{re.escape(section)}'
         if not re.search(pattern, content, re.IGNORECASE):
             missing.append(section)
     return missing


### PR DESCRIPTION
## Summary

Fixes #21 — the `session-handoff` validator's heading-match regex (`##?`) only recognized `#` and `##` headings. This caused `###` headings (which the handoff template's own nested structure uses for "Important Context" and "Immediate Next Steps") to be flagged as missing required sections.

- Expanded heading pattern from `##?` (`#{1,2}`) to `#{1,6}` in three locations: required-section detection, recommended-section detection, and the next-section boundary used for content-length measurement.
- Used `#{{1,6}}` in f-string contexts to produce the correct regex literal (bare `{1,6}` is interpreted as a format expression, not a quantifier).

## Test plan

- [ ] Run `validate_handoff.py` against the minimal reproduction case from #21 — all three required sections (`Current State Summary`, `Important Context`, `Immediate Next Steps`) should pass at `###` depth
- [ ] Run `validate_handoff.py` against a handoff using `##` headings — no regression (existing behavior preserved)
- [ ] Verify `check_recommended_sections` also recognizes `###`+ headings