### PR TITLE
docs: add Autohand Code install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,24 @@ You can also **Enable auto-update** to get the latest versions automatically.
 cp -r skills/<skill-name> ~/.claude/skills/
 ```
 
+**For Autohand Code (Manual)** — Skills only
+
+```bash
+git clone https://github.com/softaworks/agent-toolkit.git
+mkdir -p ~/.autohand/skills
+cp -r agent-toolkit/skills/<skill-name> ~/.autohand/skills/
+```
+
+For the current project:
+
+```bash
+git clone https://github.com/softaworks/agent-toolkit.git
+mkdir -p .autohand/skills
+cp -r agent-toolkit/skills/<skill-name> .autohand/skills/
+```
+
+If a skill is later published to an Autohand Skills index, install it with `autohand --skill-install <skill-name>`, or add `--project` to install it into the current project.
+
 **For claude.ai** — Skills only
 
 Add skills to project knowledge or paste SKILL.md contents into the conversation.


### PR DESCRIPTION
Hi, thanks for sharing this toolkit. The README already says the `npx skills` path works across multiple coding agents, so this adds explicit Autohand Code manual install paths for users who copy skills directly.

What changed:
- document global Autohand Code installs under `~/.autohand/skills/`
- document project-local installs under `.autohand/skills/`
- mention `autohand --skill-install <skill-name>` only for future/cataloged Autohand Skills index entries, since I did not find this repo in the current public Autohand index

Validation:
- `git diff --check`
- `python3 scripts/build_plugins.py --dry-run`