### PR TITLE
Add Ontoly Software Graph skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,6 +60,24 @@
       ]
     },
     {
+      "name": "ontoly-software-graph",
+      "description": "Use Ontoly's deterministic Software Graph and MCP capabilities for architecture review, request tracing, dependency analysis, and impact analysis.",
+      "source": "./dist/plugins/ontoly-software-graph",
+      "strict": false,
+      "skills": [
+        "./skills/ontoly-software-graph"
+      ],
+      "category": "development",
+      "keywords": [
+        "architecture",
+        "software-graph",
+        "mcp",
+        "dependencies",
+        "impact-analysis",
+        "ontoly"
+      ]
+    },
+    {
       "name": "agent-md-refactor",
       "description": "Refactor bloated AGENTS.md, CLAUDE.md, or similar agent instruction files to follow progressive disclosure principles. Splits monolithic files into organized, linked documentation.",
       "source": "./dist/plugins/agent-md-refactor",

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Add skills to project knowledge or paste SKILL.md contents into the conversation
 | 🛠️ Development | [database-schema-designer](skills/database-schema-designer/README.md) | Design robust database schemas |
 | 🛠️ Development | [dependency-updater](skills/dependency-updater/README.md) | Smart dependency management |
 | 🛠️ Development | [naming-analyzer](skills/naming-analyzer/README.md) | Suggest better variable/function names |
+| 🛠️ Development | [ontoly-software-graph](skills/ontoly-software-graph/README.md) | Graph-backed architecture, request tracing, dependency, and impact analysis |
 | 🛠️ Development | [lesson-learned](skills/lesson-learned/README.md) | Extract SE lessons from recent code changes |
 | 🛠️ Development | [reducing-entropy](skills/reducing-entropy/README.md) | Minimize codebase size |
 | 🛠️ Development | [session-handoff](skills/session-handoff/README.md) | Seamless AI session transfers |

--- a/skills/ontoly-software-graph/README.md
+++ b/skills/ontoly-software-graph/README.md
@@ -1,0 +1,24 @@
+# Ontoly Software Graph
+
+Graph-backed architecture, request tracing, dependency, and impact analysis using Ontoly's deterministic Software Graph and MCP capabilities.
+
+## Use Cases
+
+- Explain a repository's architecture from graph evidence.
+- Trace a route or request flow through controllers, services, repositories, and packages.
+- Find dependencies, consumers, and impact radius before refactors.
+- Review graph diagnostics, trust, framework detection, and semantic coverage.
+
+## Example Prompts
+
+```text
+Use Ontoly to explain this repository's architecture.
+```
+
+```text
+Use Ontoly to trace the login route through controllers, services, and repositories.
+```
+
+```text
+Use Ontoly to find what depends on UserRepository and what breaks if it changes.
+```

--- a/skills/ontoly-software-graph/SKILL.md
+++ b/skills/ontoly-software-graph/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: ontoly-software-graph
+description: Use Ontoly's deterministic Software Graph and MCP capabilities for architecture review, request tracing, dependency analysis, and impact analysis.
+---
+
+# Ontoly Software Graph
+
+Use Ontoly when an agent needs graph-backed software understanding before searching repository files directly.
+
+## When to Use
+
+- Explain repository architecture, modules, packages, services, routes, controllers, or ownership.
+- Trace a request, route, controller, service, provider, dependency, or call chain.
+- Estimate impact for removing, renaming, or refactoring a symbol, module, package, route, or service.
+- Review unresolved imports, circular dependencies, dead code, configuration usage, environment variables, or graph diagnostics.
+
+## Workflow
+
+1. Check for Ontoly artifacts such as `.ontoly/`, `SoftwareGraph.json`, diagnostics, validation output, or MCP configuration.
+2. If the graph is missing and local graph output is acceptable, run `ontoly build .`.
+3. Review diagnostics, trust, semantic coverage, framework detection, graph hash, and validation status before making claims.
+4. Prefer Ontoly CLI or MCP capabilities for architecture summaries, request tracing, dependency analysis, configuration lookup, framework reports, and impact analysis.
+5. Inspect source files only when Ontoly cannot answer, the graph is incomplete, or the user asks for source-level verification.
+
+## Output
+
+- Cite graph nodes, edges, packages, routes, diagnostics, or query outputs when available.
+- Separate measured graph facts from inference.
+- Include confidence based on graph evidence and diagnostics.
+- Explain any fallback source inspection and why it was needed.
+
+## Guardrails
+
+- Do not invent relationships that are not present in the graph.
+- Treat unresolved imports, low trust, missing framework detection, and validation failures as limitations.
+- Rebuild the graph after meaningful repository changes before answering current-state questions.


### PR DESCRIPTION
## Summary
- Add an Ontoly Software Graph skill and README.
- Add a marketplace entry for the new skill.
- Add it to the README skills table under Development.

## Validation
- python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
- python3 scripts/build_plugins.py --dry-run
- git diff --check